### PR TITLE
permisos del portal, filtro de apps por *.login y gates de layout/perfil

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,4 +70,4 @@ DOMAIN_SUFFIX=${DOMAIN_SUFFIX}
 # FDW: BD upstream donde vive v_<app>_user_permissions (maya_auth_<slot>)
 FDW_USER_PERMISSIONS_DATABASE=maya_auth_${MAYA_SLOT_DB}
 # Tras migrar auth (v_portal_user_permissions): descomenta la línea siguiente.
-# FDW_USER_PERMISSIONS_REMOTE_VIEW=v_portal_user_permissions
+FDW_USER_PERMISSIONS_REMOTE_VIEW=v_portal_user_permissions

--- a/.env.example
+++ b/.env.example
@@ -69,3 +69,5 @@ DOMAIN_SUFFIX=${DOMAIN_SUFFIX}
 
 # FDW: BD upstream donde vive v_<app>_user_permissions (maya_auth_<slot>)
 FDW_USER_PERMISSIONS_DATABASE=maya_auth_${MAYA_SLOT_DB}
+# Tras migrar auth (v_portal_user_permissions): descomenta la línea siguiente.
+# FDW_USER_PERMISSIONS_REMOTE_VIEW=v_portal_user_permissions

--- a/backend/app/DTOs/ApplicationDto.php
+++ b/backend/app/DTOs/ApplicationDto.php
@@ -16,6 +16,7 @@ final readonly class ApplicationDto
         public ?string $traefikUrl,
         public bool $isActive,
         public bool $isFavorite,
+        public ?string $viewPermissionSlug,
     ) {}
 
     public static function fromModel(Application $m): self
@@ -28,6 +29,7 @@ final readonly class ApplicationDto
             traefikUrl: $m->traefik_url,
             isActive: (bool) $m->is_active,
             isFavorite: (bool) ($m->is_favorite ?? false),
+            viewPermissionSlug: $m->view_permission_slug,
         );
     }
 }

--- a/backend/app/Http/Requests/Api/DashboardLayoutUpdateRequest.php
+++ b/backend/app/Http/Requests/Api/DashboardLayoutUpdateRequest.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Api;
 
+use App\Http\Requests\Concerns\AuthorizesByPermission;
 use Illuminate\Foundation\Http\FormRequest;
 
 class DashboardLayoutUpdateRequest extends FormRequest
 {
+    use AuthorizesByPermission;
+
     public function authorize(): bool
     {
-        return true;
+        return $this->userHasPermission('dashboard.dashboard.update');
     }
 
     public function rules(): array

--- a/backend/app/Http/Resources/ApplicationResource.php
+++ b/backend/app/Http/Resources/ApplicationResource.php
@@ -29,6 +29,7 @@ class ApplicationResource extends JsonResource
             'traefik_url' => $dto->traefikUrl,
             'is_active' => $dto->isActive,
             'is_favorite' => $dto->isFavorite,
+            'view_permission_slug' => $dto->viewPermissionSlug,
         ];
     }
 }

--- a/backend/app/Models/Application.php
+++ b/backend/app/Models/Application.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Application extends Model
 {
-    protected $fillable = ['name', 'slug', 'description', 'traefik_url', 'is_active'];
+    protected $fillable = ['name', 'slug', 'description', 'traefik_url', 'is_active', 'view_permission_slug'];
 
     public function favoritedByUsers(): BelongsToMany
     {

--- a/backend/app/Repositories/Eloquent/ApplicationRepository.php
+++ b/backend/app/Repositories/Eloquent/ApplicationRepository.php
@@ -7,6 +7,7 @@ namespace App\Repositories\Eloquent;
 use App\Models\Application;
 use App\Repositories\Contracts\ApplicationRepositoryInterface;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Maya\Profile\Database\ViewPermissionGateQuery;
 
 final class ApplicationRepository implements ApplicationRepositoryInterface
 {
@@ -17,8 +18,10 @@ final class ApplicationRepository implements ApplicationRepositoryInterface
 
     private function activeWithFavoriteFlagQuery(string $userId)
     {
-        return Application::query()
-            ->where('applications.is_active', true)
+        $query = Application::query()->where('applications.is_active', true);
+        ViewPermissionGateQuery::apply($query, $userId);
+
+        return $query
             ->leftJoin(
                 'user_favorite_applications',
                 fn ($join) => $join

--- a/backend/config/database.php
+++ b/backend/config/database.php
@@ -176,7 +176,7 @@ return [
             'schema'      => env('FDW_USER_PERMISSIONS_SCHEMA', 'public'),
             // Portal completo (logs.login, dms.login, …): v_portal_user_permissions
             // tras `php artisan migrate` en maya_authorization. Hasta entonces:
-            'remote_view' => env('FDW_USER_PERMISSIONS_REMOTE_VIEW', 'v_dashboard_user_permissions'),
+            'remote_view' => env('FDW_USER_PERMISSIONS_REMOTE_VIEW', 'v_portal_user_permissions'),
         ],
     ],
 

--- a/backend/config/database.php
+++ b/backend/config/database.php
@@ -174,6 +174,8 @@ return [
             'username'    => env('FDW_USER_PERMISSIONS_USERNAME', 'maya'),
             'password'    => env('FDW_USER_PERMISSIONS_PASSWORD', 'secret'),
             'schema'      => env('FDW_USER_PERMISSIONS_SCHEMA', 'public'),
+            // Portal completo (logs.login, dms.login, …): v_portal_user_permissions
+            // tras `php artisan migrate` en maya_authorization. Hasta entonces:
             'remote_view' => env('FDW_USER_PERMISSIONS_REMOTE_VIEW', 'v_dashboard_user_permissions'),
         ],
     ],

--- a/backend/database/migrations/2026_05_21_000001_add_view_permission_slug_to_applications.php
+++ b/backend/database/migrations/2026_05_21_000001_add_view_permission_slug_to_applications.php
@@ -1,0 +1,93 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Añade view_permission_slug al catálogo de aplicaciones (FDW → maya_auth).
+ */
+return new class extends Migration
+{
+    private const SERVER  = 'maya_auth_server';
+    private const FDW_TBL = 'applications';
+
+    public function up(): void
+    {
+        if ($this->isTestEnv()) {
+            Schema::table(self::FDW_TBL, function (Blueprint $table) {
+                $table->string('view_permission_slug', 150)->nullable()->after('is_active');
+            });
+
+            return;
+        }
+
+        $this->recreateFdwTable();
+    }
+
+    public function down(): void
+    {
+        if ($this->isTestEnv()) {
+            Schema::table(self::FDW_TBL, function (Blueprint $table) {
+                $table->dropColumn('view_permission_slug');
+            });
+
+            return;
+        }
+
+        $this->recreateFdwTableWithoutSlug();
+    }
+
+    private function isTestEnv(): bool
+    {
+        if (app()->environment('testing')) {
+            return true;
+        }
+
+        $db = config('database.connections.pgsql.database');
+
+        return is_string($db) && str_ends_with($db, '_test');
+    }
+
+    private function recreateFdwTable(): void
+    {
+        DB::statement('DROP FOREIGN TABLE IF EXISTS ' . self::FDW_TBL . ' CASCADE');
+
+        DB::statement('
+            CREATE FOREIGN TABLE ' . self::FDW_TBL . ' (
+                id                    bigint        NOT NULL,
+                name                  varchar(255)  NOT NULL,
+                slug                  varchar(100)  NOT NULL,
+                description           text,
+                traefik_url           varchar(2048),
+                is_active             boolean       NOT NULL DEFAULT true,
+                view_permission_slug  varchar(150),
+                created_at            timestamp,
+                updated_at            timestamp
+            )
+            SERVER ' . self::SERVER . '
+            OPTIONS (schema_name \'public\', table_name \'applications\')
+        ');
+    }
+
+    private function recreateFdwTableWithoutSlug(): void
+    {
+        DB::statement('DROP FOREIGN TABLE IF EXISTS ' . self::FDW_TBL . ' CASCADE');
+
+        DB::statement('
+            CREATE FOREIGN TABLE ' . self::FDW_TBL . ' (
+                id          bigint        NOT NULL,
+                name        varchar(255)  NOT NULL,
+                slug        varchar(100)  NOT NULL,
+                description text,
+                traefik_url varchar(2048),
+                is_active   boolean       NOT NULL DEFAULT true,
+                created_at  timestamp,
+                updated_at  timestamp
+            )
+            SERVER ' . self::SERVER . '
+            OPTIONS (schema_name \'public\', table_name \'applications\')
+        ');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -8,7 +8,7 @@ use App\Http\Controllers\Api\V1\Dashboard\UserDashboardLayoutController;
 use App\Http\Controllers\Api\V1\Dashboard\UserFavoriteApplicationController;
 use App\Http\Controllers\Api\V1\Notifications\NotificationController;
 use Illuminate\Support\Facades\Route;
-use Maya\Profile\Routing\MeRoutes;
+use Maya\Profile\Controllers\MeController;
 
 Route::middleware(['auth.keycloak', 'user.owns.resource'])
     ->prefix('v1/dashboard/user/{user}')
@@ -20,12 +20,16 @@ Route::middleware(['auth.keycloak', 'user.owns.resource'])
         Route::get('applications', [ApplicationController::class, 'index']);
 
         Route::get('dashboard-layout', [UserDashboardLayoutController::class, 'show']);
-        Route::put('dashboard-layout', [UserDashboardLayoutController::class, 'update']);
+        Route::put('dashboard-layout', [UserDashboardLayoutController::class, 'update'])
+            ->middleware('permission:dashboard.dashboard.update');
     });
 
-// Perfil del usuario autenticado — endpoints en maya/shared-profile-laravel.
+// Perfil del usuario autenticado — maya/shared-profile-laravel.
+// GET /me sin profile.show: lo usa el portal para login, permisos y layout.
 Route::middleware('auth.keycloak')->prefix('v1')->group(function () {
-    MeRoutes::register();
+    Route::get('/me', [MeController::class, 'show']);
+    Route::put('/me/locale', [MeController::class, 'updateLocale'])
+        ->middleware('permission:profile.update');
 });
 
 // Notifications (per authenticated user)

--- a/backend/tests/Feature/Api/ApplicationTest.php
+++ b/backend/tests/Feature/Api/ApplicationTest.php
@@ -4,6 +4,7 @@ use App\Models\Application;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Routing\Events\RouteMatched;
+use Illuminate\Support\Facades\DB;
 
 uses(RefreshDatabase::class);
 
@@ -37,13 +38,38 @@ function makeApplication(array $overrides = []): Application
 // ─── index ────────────────────────────────────────────────────────────────────
 
 it('returns active applications for the user', function () {
-    makeApplication(['is_active' => true]);
-    makeApplication(['is_active' => true]);
+    makeApplication(['is_active' => true, 'view_permission_slug' => null]);
+    makeApplication(['is_active' => true, 'view_permission_slug' => null]);
 
     $response = $this->getJson("/api/v1/dashboard/user/{$this->user->id}/applications");
 
     $response->assertOk();
     expect($response->json('data'))->toHaveCount(2);
+});
+
+it('only returns applications whose view_permission_slug the user has in FDW', function () {
+    $visible = makeApplication([
+        'slug'                 => 'maya-logs',
+        'view_permission_slug' => 'logs.login',
+        'is_active'            => true,
+    ]);
+    makeApplication([
+        'slug'                 => 'maya-dms',
+        'view_permission_slug' => 'dms.login',
+        'is_active'            => true,
+    ]);
+
+    DB::table('user_resolved_permissions')->insert([
+        'user_id'         => $this->user->id,
+        'permission_slug' => 'logs.login',
+    ]);
+
+    $response = $this->getJson("/api/v1/dashboard/user/{$this->user->id}/applications");
+
+    $response->assertOk();
+    expect($response->json('data'))->toHaveCount(1);
+    expect($response->json('data.0.id'))->toBe($visible->id);
+    expect($response->json('data.0.view_permission_slug'))->toBe('logs.login');
 });
 
 it('excludes inactive applications', function () {
@@ -109,7 +135,7 @@ it('response contains expected application fields', function () {
 
     $response->assertOk();
     $app = $response->json('data.0');
-    expect($app)->toHaveKeys(['id', 'name', 'slug', 'description', 'traefik_url', 'is_active', 'is_favorite']);
+    expect($app)->toHaveKeys(['id', 'name', 'slug', 'description', 'traefik_url', 'is_active', 'is_favorite', 'view_permission_slug']);
     expect($app['name'])->toBe('Named App');
     expect($app['slug'])->toBe('named-app');
 });

--- a/backend/tests/Feature/Api/DashboardLayoutTest.php
+++ b/backend/tests/Feature/Api/DashboardLayoutTest.php
@@ -4,12 +4,19 @@ use App\Models\User;
 use App\Models\UserDashboardLayout;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Routing\Events\RouteMatched;
+use Illuminate\Support\Facades\DB;
 
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
+    config(['cache.default' => 'array']);
     $this->withoutMiddleware(\Maya\Auth\Middleware\JwtMiddleware::class);
     $this->user = User::factory()->create();
+
+    DB::table('user_resolved_permissions')->insert([
+        'user_id'         => $this->user->id,
+        'permission_slug' => 'dashboard.dashboard.update',
+    ]);
 
     // Inject jwt_user attribute (normally set by JwtMiddleware) so that
     // EnsureRouteUserMatchesToken accepts the request and downstream code
@@ -71,6 +78,17 @@ it('rejects negative coordinates', function () {
     $this->putJson("/api/v1/dashboard/user/{$this->user->id}/dashboard-layout", [
         'layout' => [['i' => 'widget-1', 'x' => -1, 'y' => 0, 'w' => 4, 'h' => 2]],
     ])->assertUnprocessable();
+});
+
+it('denies layout update without dashboard.dashboard.update', function () {
+    DB::table('user_resolved_permissions')
+        ->where('user_id', $this->user->id)
+        ->where('permission_slug', 'dashboard.dashboard.update')
+        ->delete();
+
+    $this->putJson("/api/v1/dashboard/user/{$this->user->id}/dashboard-layout", [
+        'layout' => [['i' => 'widget-1', 'x' => 0, 'y' => 0, 'w' => 4, 'h' => 2]],
+    ])->assertForbidden();
 });
 
 it('response contains updated_at timestamp', function () {

--- a/backend/tests/Feature/Api/MeLoginPermissionsTest.php
+++ b/backend/tests/Feature/Api/MeLoginPermissionsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Events\RouteMatched;
+use Illuminate\Support\Facades\DB;
+use Maya\Auth\Middleware\JwtMiddleware;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config(['cache.default' => 'array']);
+    $this->withoutMiddleware([JwtMiddleware::class]);
+
+    $this->user = User::factory()->create();
+
+    $userId = $this->user->id;
+    $this->app['events']->listen(RouteMatched::class, function ($event) use ($userId) {
+        $event->request->attributes->set('jwt_user', [
+            'id'  => $userId,
+            'sub' => $userId,
+        ]);
+    });
+});
+
+it('exposes cross-app login permissions in GET me permissions array', function () {
+    DB::table('user_resolved_permissions')->insert([
+        ['user_id' => $this->user->id, 'permission_slug' => 'dashboard.login'],
+        ['user_id' => $this->user->id, 'permission_slug' => 'logs.login'],
+        ['user_id' => $this->user->id, 'permission_slug' => 'dms.login'],
+    ]);
+
+    $response = $this->getJson('/api/v1/me');
+
+    $response->assertOk();
+    $permissions = $response->json('data.permissions');
+    expect($permissions)->toContain('dashboard.login', 'logs.login', 'dms.login');
+});

--- a/backend/tests/Feature/Api/ProfileLocaleTest.php
+++ b/backend/tests/Feature/Api/ProfileLocaleTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Events\RouteMatched;
+use Illuminate\Support\Facades\DB;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config(['cache.default' => 'array']);
+    $this->withoutMiddleware(\Maya\Auth\Middleware\JwtMiddleware::class);
+    $this->user = User::factory()->create();
+
+    DB::table('user_resolved_permissions')->insert([
+        'user_id'         => $this->user->id,
+        'permission_slug' => 'profile.update',
+    ]);
+
+    $userId = $this->user->id;
+    $this->app['events']->listen(RouteMatched::class, function ($event) use ($userId) {
+        $event->request->attributes->set('jwt_user', [
+            'id'  => $userId,
+            'sub' => $userId,
+        ]);
+    });
+});
+
+it('allows locale update with profile.update', function () {
+    $this->putJson('/api/v1/me/locale', ['locale' => 'es'])
+        ->assertOk();
+});
+
+it('denies locale update without profile.update', function () {
+    DB::table('user_resolved_permissions')
+        ->where('user_id', $this->user->id)
+        ->where('permission_slug', 'profile.update')
+        ->delete();
+
+    $this->putJson('/api/v1/me/locale', ['locale' => 'es'])
+        ->assertForbidden();
+});
+
+it('allows GET me without profile.show', function () {
+    DB::table('user_resolved_permissions')
+        ->where('user_id', $this->user->id)
+        ->delete();
+
+    $this->getJson('/api/v1/me')
+        ->assertOk();
+});

--- a/backend/tests/Unit/DTOs/ApplicationDtoTest.php
+++ b/backend/tests/Unit/DTOs/ApplicationDtoTest.php
@@ -15,6 +15,7 @@ it('creates ApplicationDto from model with all fields', function () {
     $model->setAttribute('id', 1);
     // is_favorite comes from a raw query select, simulate it as attribute
     $model->setAttribute('is_favorite', true);
+    $model->setAttribute('view_permission_slug', 'auth.login');
 
     $dto = ApplicationDto::fromModel($model);
 
@@ -25,6 +26,7 @@ it('creates ApplicationDto from model with all fields', function () {
     expect($dto->traefikUrl)->toBe('https://auth.maya.test');
     expect($dto->isActive)->toBeTrue();
     expect($dto->isFavorite)->toBeTrue();
+    expect($dto->viewPermissionSlug)->toBe('auth.login');
 });
 
 it('defaults isFavorite to false when is_favorite attribute is null', function () {
@@ -65,6 +67,7 @@ it('ApplicationDto is immutable (readonly)', function () {
         traefikUrl: null,
         isActive: true,
         isFavorite: false,
+        viewPermissionSlug: 'logs.login',
     );
 
     expect(fn () => $dto->id = 999)->toThrow(Error::class);

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -54,6 +54,9 @@ vi.mock('./features/favorites/context/FavoritesContext', () => ({
 
 vi.mock('./features/user-profile', () => ({
   UserProfileProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useUserProfile: vi.fn(() => ({
+    hasPermission: () => true,
+  })),
 }))
 
 // Lazy page mocks — loaded synchronously

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,11 +5,13 @@ import { AppLayout } from '@maya/shared-layout-react'
 import { NotificationsBell, SidebarFavorites } from '@maya/shared-sidebar-react'
 import { useKeycloakLocaleSync } from '@maya/shared-i18n-react'
 import { useAuth, useOidcSession } from '@maya/shared-auth-react'
+import { useLogoutWithoutLoginPermission } from '@maya/shared-profile-react'
 import { Button, ErrorBoundary, SkeletonPage, ToastProvider } from '@maya/shared-ui-react'
 import { useNavItems } from './components/layout'
 import { FavoritesProvider } from './features/favorites/context/FavoritesContext'
 import { UserProfileProvider } from './features/user-profile'
 import { resolveServiceUrl } from './lib/peerService'
+import { DASHBOARD_PERMISSIONS } from './permissions'
 
 function ErrorFallback() {
   const { t } = useTranslation('common')
@@ -145,7 +147,34 @@ function AppProviders({ children }: { children: ReactNode }) {
   )
 }
 
+function AuthLoadingScreen({ message }: { message: string }) {
+  return (
+    <div className="flex items-center justify-center h-screen bg-ui-body dark:bg-ui-dark-bg text-text-muted dark:text-text-dark-muted font-sans">
+      {message}
+    </div>
+  )
+}
+
+/** Requiere dashboard.login en /me; si falta, cierra sesión SSO. */
+function AppAfterProfile() {
+  const { t } = useTranslation('auth')
+  const { profileLoading, lacksLoginPermission } = useLogoutWithoutLoginPermission(
+    DASHBOARD_PERMISSIONS.login,
+  )
+
+  if (profileLoading) {
+    return <AuthLoadingScreen message={t('initializing')} />
+  }
+
+  if (lacksLoginPermission) {
+    return <AuthLoadingScreen message={t('signingOutNoPermission')} />
+  }
+
+  return <AppWithLayout />
+}
+
 export default function App() {
+  const { t } = useTranslation('auth')
   const { isOidcLoading, isOidcSignedIn, beginSignIn } = useOidcSession()
 
   useEffect(() => {
@@ -155,24 +184,16 @@ export default function App() {
   }, [isOidcLoading, isOidcSignedIn, beginSignIn])
 
   if (isOidcLoading) {
-    return (
-      <div className="flex items-center justify-center h-screen bg-ui-body dark:bg-ui-dark-bg text-text-muted dark:text-text-dark-muted font-sans">
-        Iniciando sesión…
-      </div>
-    )
+    return <AuthLoadingScreen message={t('initializing')} />
   }
 
   if (!isOidcSignedIn) {
-    return (
-      <div className="flex items-center justify-center h-screen bg-ui-body dark:bg-ui-dark-bg text-text-muted dark:text-text-dark-muted font-sans">
-        Redirigiendo al inicio de sesión...
-      </div>
-    )
+    return <AuthLoadingScreen message={t('redirecting')} />
   }
 
   return (
     <AppProviders>
-      <AppWithLayout />
+      <AppAfterProfile />
     </AppProviders>
   )
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,7 @@ import { useLogoutWithoutLoginPermission } from '@maya/shared-profile-react'
 import { Button, ErrorBoundary, SkeletonPage, ToastProvider } from '@maya/shared-ui-react'
 import { useNavItems } from './components/layout'
 import { FavoritesProvider } from './features/favorites/context/FavoritesContext'
-import { UserProfileProvider } from './features/user-profile'
+import { UserProfileProvider, useUserProfile } from './features/user-profile'
 import { resolveServiceUrl } from './lib/peerService'
 import { DASHBOARD_PERMISSIONS } from './permissions'
 
@@ -94,6 +94,8 @@ function AppRoutes() {
 
 function AppWithLayout() {
   const { logout, user } = useOidcSession()
+  const { hasPermission } = useUserProfile()
+  const canShowProfile = hasPermission(DASHBOARD_PERMISSIONS.profileShow)
   const navItems = useNavItems()
   const { t } = useTranslation('common')
   const navigate = useNavigate()
@@ -117,7 +119,7 @@ function AppWithLayout() {
         userEmail={userEmail}
         userInitials={userInitials}
         onLogout={logout}
-        onProfile={() => navigate('/profile')}
+        onProfile={canShowProfile ? () => navigate('/profile') : undefined}
         favoritesSlot={
           <SidebarFavorites label={t('favorites.title')} dashboardApiUrl={DASHBOARD_API_URL} />
         }

--- a/frontend/src/features/applications/api/applicationMapper.ts
+++ b/frontend/src/features/applications/api/applicationMapper.ts
@@ -19,6 +19,7 @@ function mapApplicationFromApi(app: any) {
     description: app.description,
     isFavorite: Boolean(app.is_favorite),
     documentationUrl: app.traefik_url || app.documentation_url || defaultUrl,
+    viewPermissionSlug: app.view_permission_slug ?? null,
     lastUsedAt: validateIsoDate(app.last_used_at || app.updated_at),
   }
 }

--- a/frontend/src/features/applications/hooks/useApplicationsData.ts
+++ b/frontend/src/features/applications/hooks/useApplicationsData.ts
@@ -2,13 +2,16 @@ import { useCallback, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useAuth } from '@maya/shared-auth-react'
 import { useLocale } from '@maya/shared-i18n-react'
+import { canAccessByViewPermission } from '@maya/shared-profile-react'
 import { getApplicationsData } from '../api/applicationsApi'
 import { useFavoritesContext } from '../../favorites/context/FavoritesContext'
+import { useUserProfile } from '../../user-profile'
 
 function useApplicationsData() {
   const { user, token } = useAuth()
   const { t } = useLocale()
   const { favorites, add, remove } = useFavoritesContext()
+  const { hasPermission } = useUserProfile()
 
   const { data: rawApps = [], isLoading: loading, error: queryError } = useQuery({
     queryKey: ['applications', user?.sub],
@@ -27,10 +30,16 @@ function useApplicationsData() {
 
   const favoriteIds = useMemo(() => new Set(favorites.map((f) => f.id)), [favorites])
 
-  const apps = useMemo(
-    () => rawApps.map((app) => ({ ...app, isFavorite: favoriteIds.has(app.id) })),
-    [rawApps, favoriteIds],
-  )
+  const apps = useMemo(() => {
+    const accessible = rawApps.filter((app) =>
+      canAccessByViewPermission(app.viewPermissionSlug, hasPermission),
+    )
+
+    return accessible.map((app) => ({
+      ...app,
+      isFavorite: favoriteIds.has(app.id),
+    }))
+  }, [rawApps, favoriteIds, hasPermission])
 
   const toggleFavorite = useCallback(
     (id: string | number) => {

--- a/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
@@ -112,6 +112,14 @@ vi.mock('@maya/shared-i18n-react', () => ({
   useLocale: vi.fn(),
 }))
 
+const hasPermissionMock = vi.fn(() => true)
+
+vi.mock('../../user-profile', () => ({
+  useUserProfile: () => ({
+    hasPermission: hasPermissionMock,
+  }),
+}))
+
 import useDashboardLayout from '../../dashboard-layout/hooks/useDashboardLayout'
 import { useToast } from '@maya/shared-ui-react'
 import { useLocale } from '@maya/shared-i18n-react'
@@ -150,6 +158,7 @@ function setupMocks({ loading = false } = {}) {
 describe('DashboardPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    hasPermissionMock.mockReturnValue(true)
     setupMocks()
     saveLayoutMock.mockResolvedValue(undefined)
     resetToDefaultMock.mockResolvedValue(undefined)
@@ -179,9 +188,15 @@ describe('DashboardPage', () => {
       expect(screen.getByText('dashboard.title')).toBeTruthy()
     })
 
-    it('muestra el botón de toggle edición', () => {
+    it('muestra el botón de toggle edición con dashboard.dashboard.update', () => {
       render(<DashboardPage />)
       expect(screen.getByTestId('edit-toggle')).toBeTruthy()
+    })
+
+    it('oculta el botón de edición sin dashboard.dashboard.update', () => {
+      hasPermissionMock.mockReturnValue(false)
+      render(<DashboardPage />)
+      expect(screen.queryByTestId('edit-toggle')).toBeNull()
     })
 
     it('no muestra la toolbar de edición en modo normal', () => {

--- a/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -21,6 +21,8 @@ import {
 import { WIDGET_REGISTRY } from '../widgets/registry'
 import { PageTitle, useToast } from '@maya/shared-ui-react'
 import { useLocale } from '@maya/shared-i18n-react'
+import { useUserProfile } from '../../user-profile'
+import { DASHBOARD_PERMISSIONS } from '../../../permissions'
 
 const SKELETON_BLOCKS: SkeletonBlock[] = [
   { colSpanClasses: 'col-span-12 sm:col-span-6', heightClass: 'h-48' },
@@ -30,6 +32,8 @@ const SKELETON_BLOCKS: SkeletonBlock[] = [
 
 function DashboardPage() {
   const { layout, loading, saveLayout, resetToDefault } = useDashboardLayout()
+  const { hasPermission } = useUserProfile()
+  const canEditLayout = hasPermission(DASHBOARD_PERMISSIONS.dashboardUpdate)
   const [editable, setEditable] = useState(false)
   const [draftLayout, setDraftLayout] = useState<Layout | null>(null)
   const snapshotRef = useRef<Layout | null>(null)
@@ -39,6 +43,7 @@ function DashboardPage() {
   const activeLayout = editable ? (draftLayout ?? layout) : layout
 
   const handleToggleEdit = useCallback(() => {
+    if (!canEditLayout) return
     setEditable((prev) => {
       if (prev) {
         setDraftLayout(null)
@@ -48,7 +53,7 @@ function DashboardPage() {
       setDraftLayout(layout as Layout)
       return true
     })
-  }, [layout])
+  }, [canEditLayout, layout])
 
   const handleSave = useCallback(async () => {
     try {
@@ -112,7 +117,7 @@ function DashboardPage() {
       <PageTitle
         title={t('dashboard.title')}
         actions={
-          editable ? (
+          canEditLayout && editable ? (
             <DashboardEditToolbar
               layout={activeLayout}
               registry={WIDGET_REGISTRY}
@@ -128,9 +133,9 @@ function DashboardPage() {
                 addWidget: t('dashboard.addWidget'),
               }}
             />
-          ) : (
+          ) : canEditLayout ? (
             <DashboardEditToggleButton editable={editable} onToggle={handleToggleEdit} />
-          )
+          ) : null
         }
       />
 

--- a/frontend/src/features/profile/pages/ProfilePage.test.tsx
+++ b/frontend/src/features/profile/pages/ProfilePage.test.tsx
@@ -24,6 +24,14 @@ vi.mock('../api/profileApi', () => ({
   updateProfile: vi.fn(),
 }))
 
+const hasPermissionMock = vi.fn((_slug: string) => true)
+
+vi.mock('../../user-profile', () => ({
+  useUserProfile: () => ({
+    hasPermission: hasPermissionMock,
+  }),
+}))
+
 vi.mock('@maya/shared-ui-react', () => ({
   Button: ({
     children,
@@ -150,6 +158,7 @@ function setupMocks({
 describe('ProfilePage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    hasPermissionMock.mockImplementation(() => true)
     setupMocks()
   })
 
@@ -168,6 +177,28 @@ describe('ProfilePage', () => {
       setupMocks({ user: null })
       render(<ProfilePage />)
       expect(screen.queryByTestId('page-title')).toBeNull()
+    })
+  })
+
+  describe('permisos', () => {
+    it('muestra mensaje sin profile.show', () => {
+      hasPermissionMock.mockImplementation((slug: string) => slug !== 'profile.show')
+      render(<ProfilePage />)
+      expect(screen.getByText('profile.noPermission')).toBeTruthy()
+      expect(screen.queryByText('Juan')).toBeNull()
+    })
+
+    it('oculta el botón de editar sin profile.update', () => {
+      hasPermissionMock.mockImplementation((slug: string) => slug === 'profile.show')
+      render(<ProfilePage />)
+      expect(screen.queryByText('profile.edit')).toBeNull()
+      expect(screen.getByText('Juan')).toBeTruthy()
+    })
+
+    it('deshabilita el selector de idioma sin profile.update', () => {
+      hasPermissionMock.mockImplementation((slug: string) => slug === 'profile.show')
+      render(<ProfilePage />)
+      expect(screen.getByRole('combobox')).toHaveProperty('disabled', true)
     })
   })
 
@@ -303,7 +334,8 @@ describe('ProfilePage', () => {
       expect(select).toBeTruthy()
     })
 
-    it('llama updateMyLocale al cambiar el idioma', async () => {
+    it('llama updateMyLocale al cambiar el idioma con profile.update', async () => {
+      hasPermissionMock.mockImplementation(() => true)
       mockUpdateMyLocale.mockResolvedValueOnce(undefined)
       render(<ProfilePage />)
       const select = screen.getByRole('combobox')
@@ -311,6 +343,16 @@ describe('ProfilePage', () => {
         fireEvent.change(select, { target: { value: 'en' } })
       })
       expect(mockUpdateMyLocale).toHaveBeenCalledWith('en')
+    })
+
+    it('no llama updateMyLocale sin profile.update', async () => {
+      hasPermissionMock.mockImplementation((slug: string) => slug === 'profile.show')
+      render(<ProfilePage />)
+      const select = screen.getByRole('combobox')
+      await act(async () => {
+        fireEvent.change(select, { target: { value: 'en' } })
+      })
+      expect(mockUpdateMyLocale).not.toHaveBeenCalled()
     })
 
     it('no llama updateMyLocale cuando el idioma seleccionado es el actual', async () => {

--- a/frontend/src/features/profile/pages/ProfilePage.tsx
+++ b/frontend/src/features/profile/pages/ProfilePage.tsx
@@ -13,6 +13,8 @@ import {
 } from '@maya/shared-ui-react'
 import { useLocale } from '@maya/shared-i18n-react'
 import { updateMyLocale } from '../../../api/auth'
+import { useUserProfile } from '../../user-profile'
+import { DASHBOARD_PERMISSIONS } from '../../../permissions'
 import { updateProfile } from '../api/profileApi'
 import {
   createProfileFormSchema,
@@ -105,6 +107,9 @@ function ProfileSection({ title, children }: { title: string; children: React.Re
 function ProfilePage() {
   const { user: authUser } = useAuth()
   const user = authUser as ProfileUser | null
+  const { hasPermission } = useUserProfile()
+  const canShow = hasPermission(DASHBOARD_PERMISSIONS.profileShow)
+  const canUpdate = hasPermission(DASHBOARD_PERMISSIONS.profileUpdate)
   const { t } = useLocale()
   const navigate = useNavigate()
   const [isEditing, setIsEditing] = useState(false)
@@ -127,7 +132,19 @@ function ProfilePage() {
     return <p className="text-text-primary dark:text-text-dark-primary">{t('profile.noUser')}</p>
   }
 
+  if (!canShow) {
+    return (
+      <>
+        <PageTitle title={t('profile.title')} onBack={() => navigate(-1)} />
+        <p className="text-text-primary dark:text-text-dark-primary" role="status">
+          {t('profile.noPermission')}
+        </p>
+      </>
+    )
+  }
+
   const handleEdit = () => {
+    if (!canUpdate) return
     reset({
       name: user.name ?? '',
       surname: user.surname ?? '',
@@ -154,6 +171,7 @@ function ProfilePage() {
   }
 
   const onSubmit = handleSubmit(async (values) => {
+    if (!canUpdate) return
     setSaveError(null)
     try {
       const updatedUser = await updateProfile({ id: user.id, ...values })
@@ -185,7 +203,7 @@ function ProfilePage() {
         }
         onBack={() => navigate(-1)}
         actions={
-          !isEditing ? (
+          !isEditing && canUpdate ? (
             <Button variant="primary" size="sm" onClick={handleEdit} className="w-full sm:w-auto">
               {t('profile.edit')}
             </Button>
@@ -267,7 +285,7 @@ function ProfilePage() {
             </dl>
           </div>
 
-          <PreferencesCard />
+          <PreferencesCard canUpdate={canUpdate} />
         </section>
       ) : (
         <section className="max-w-[600px] mx-auto min-w-0">
@@ -332,7 +350,7 @@ function ProfilePage() {
  * Tarjeta de preferencias en el perfil. Único punto de cambio de idioma
  * en el ecosistema (no hay selector en el sidebar).
  */
-function PreferencesCard() {
+function PreferencesCard({ canUpdate }: { canUpdate: boolean }) {
   const { t, locale, setLocale, localeOptions } = useLocale()
   const [savingLocale, setSavingLocale] = useState(false)
 
@@ -340,7 +358,7 @@ function PreferencesCard() {
   // exista la escritura real a Odoo la UI esté ya lista. Tras 200 OK aplica
   // el cambio local (i18next + localStorage + maya_user_profile.locale).
   const handleLocaleChange = async (next: string) => {
-    if (next === locale || savingLocale) return
+    if (!canUpdate || next === locale || savingLocale) return
     setSavingLocale(true)
     try {
       await updateMyLocale(next)
@@ -365,7 +383,7 @@ function PreferencesCard() {
           id="profile-locale-select"
           fieldSize="md"
           value={locale}
-          disabled={savingLocale}
+          disabled={savingLocale || !canUpdate}
           onChange={(e) => void handleLocaleChange(e.target.value)}
           className="max-w-[260px]"
         >

--- a/frontend/src/permissions.ts
+++ b/frontend/src/permissions.ts
@@ -1,0 +1,7 @@
+/** Permisos del portal (maya-dashboard), alineados con maya_authorization. */
+export const DASHBOARD_PERMISSIONS = {
+  login: 'dashboard.login',
+  dashboardUpdate: 'dashboard.dashboard.update',
+  profileShow: 'profile.show',
+  profileUpdate: 'profile.update',
+} as const

--- a/frontend/src/shared/i18n/locales/en/auth.ts
+++ b/frontend/src/shared/i18n/locales/en/auth.ts
@@ -1,4 +1,8 @@
 export default {
+  initializing: 'Signing in…',
+  redirecting: 'Redirecting to sign in…',
+  signingOutNoPermission:
+    'You do not have permission to access the portal. Signing out…',
   loginTitle: 'Log in',
   loginSubtitle: 'Enter your credentials to access.',
   registerTitle: 'Register',

--- a/frontend/src/shared/i18n/locales/en/profile.ts
+++ b/frontend/src/shared/i18n/locales/en/profile.ts
@@ -10,6 +10,7 @@ export default {
   save: 'Save changes',
   saving: 'Saving...',
   noUser: 'No user information available',
+  noPermission: 'You do not have permission to view the profile.',
   saveError: 'Error saving profile.',
   errorUpdate: 'Could not update profile.',
   basicData: 'Basic data',

--- a/frontend/src/shared/i18n/locales/es/auth.ts
+++ b/frontend/src/shared/i18n/locales/es/auth.ts
@@ -1,4 +1,8 @@
 export default {
+  initializing: 'Iniciando sesión…',
+  redirecting: 'Redirigiendo al inicio de sesión…',
+  signingOutNoPermission:
+    'No tienes permiso para acceder al portal. Cerrando sesión…',
   loginTitle: 'Iniciar sesión',
   loginSubtitle: 'Introduce tus credenciales para acceder.',
   registerTitle: 'Registro',

--- a/frontend/src/shared/i18n/locales/es/profile.ts
+++ b/frontend/src/shared/i18n/locales/es/profile.ts
@@ -10,6 +10,7 @@ export default {
   save: 'Guardar cambios',
   saving: 'Guardando...',
   noUser: 'No hay información de usuario',
+  noPermission: 'No tienes permiso para ver el perfil.',
   saveError: 'Error al guardar el perfil.',
   errorUpdate: 'No se pudo actualizar el perfil.',
   basicData: 'Datos básicos',

--- a/frontend/src/shared/i18n/locales/va/auth.ts
+++ b/frontend/src/shared/i18n/locales/va/auth.ts
@@ -1,4 +1,8 @@
 export default {
+  initializing: 'Iniciant sessió…',
+  redirecting: 'Redirigint a l\'inici de sessió…',
+  signingOutNoPermission:
+    'No tens permís per accedir al portal. Tancant sessió…',
   loginTitle: 'Iniciar sessió',
   loginSubtitle: 'Introduïx les teues credencials per accedir.',
   registerTitle: 'Registre',

--- a/frontend/src/shared/i18n/locales/va/profile.ts
+++ b/frontend/src/shared/i18n/locales/va/profile.ts
@@ -10,6 +10,7 @@ export default {
   save: 'Guardar canvis',
   saving: 'Guardant...',
   noUser: "No hi ha informació d'usuari",
+  noPermission: 'No tens permís per veure el perfil.',
   saveError: 'Error en guardar el perfil.',
   errorUpdate: "No s'ha pogut actualitzar el perfil.",
   basicData: 'Dades bàsiques',


### PR DESCRIPTION
Refactor de permisos del portal (maya-dashboard) alineado con el catálogo de maya_authorization: gate de entrada `dashboard.login`, permisos finos de panel y perfil, y listado de aplicaciones filtrado por `view_permission_slug` (p. ej. `logs.login`, `dms.login`) usando permisos resueltos vía FDW.

Incluye el uso de v_portal_user_permissions en la FDW de permisos (no v_dashboard_user_permissions), para que GET /me y el listado de aplicaciones expongan todos los *.login del usuario (TraCEED, DocuCEED, AudiCEED, etc.).

Backend:
- Migración FDW: columna `view_permission_slug` en el catálogo de aplicaciones (`applications`).
- `ApplicationRepository` + `ViewPermissionGateQuery`: el listado solo devuelve apps cuyo `view_permission_slug` el usuario tiene en `user_resolved_permissions`.
- `GET /me` sigue sin middleware de perfil (arranque del portal); `PUT /me/locale` exige `profile.update`.
- `PUT …/dashboard-layout` exige `dashboard.dashboard.update` (middleware + `DashboardLayoutUpdateRequest`).
- Tests: aplicaciones filtradas por permiso, layout 403 sin update, `/me` con array `permissions[]`, locale con `profile.update`.
- Config: default FDW_USER_PERMISSIONS_REMOTE_VIEW=v_portal_user_permissions en config/database.php y .env.example.

Frontend:
- Constantes en `permissions.ts` (`dashboard.login`, `dashboard.dashboard.update`, `profile.show`, `profile.update`).
- `useLogoutWithoutLoginPermission('dashboard.login')`: sin permiso de portal → cierre de sesión SSO.
- Listado de aplicaciones: `canAccessByViewPermission(viewPermissionSlug, hasPermission)` sobre `permissions[]` de `/me`.
- Panel: botón editar layout solo con `dashboard.dashboard.update`.
- Perfil: ver / editar / idioma según `profile.show` y `profile.update`; enlace “Perfil” en menú solo con `profile.show`.
- i18n (es/en/va): mensajes de inicialización y sin permiso de portal.