### PR TITLE
Feature/destinatarios alertas

### DIFF
--- a/backend/app/Console/Commands/EvaluateAlertRules.php
+++ b/backend/app/Console/Commands/EvaluateAlertRules.php
@@ -10,7 +10,7 @@ use Cron\CronExpression;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
-use Maya\Messaging\Publishers\AlertPublisher;
+use App\Services\Contracts\SystemAlertDispatchServiceInterface;
 use Throwable;
 
 /**
@@ -27,8 +27,10 @@ class EvaluateAlertRules extends Command
 
     protected $description = 'Run each enabled alert rule and publish matching alerts to maya.alerts';
 
-    public function handle(AlertPublisher $publisher, AlertRuleRepositoryInterface $ruleRepo): int
-    {
+    public function handle(
+        SystemAlertDispatchServiceInterface $dispatch,
+        AlertRuleRepositoryInterface $ruleRepo,
+    ): int {
         $logsConnection = (string) $this->option('logs-connection');
         $now = now();
 
@@ -74,13 +76,7 @@ class EvaluateAlertRules extends Command
             // sample_columns is metadata for redaction, not part of the alert payload.
             unset($context['sample_columns']);
 
-            $publisher->publish(
-                ruleSlug: $rule->slug,
-                severity: $rule->severity,
-                title: $rule->name,
-                context: $context,
-                source: 'logs.aggregation',
-            );
+            $dispatch->dispatchTriggeredRule($rule, $context);
 
             $this->line("  → alert published: {$rule->slug} ({$rule->severity}, {$context['matched_rows']} rows)");
         }

--- a/backend/app/DTOs/AlertAudienceDto.php
+++ b/backend/app/DTOs/AlertAudienceDto.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+use App\Models\AlertRule;
+use App\Models\PanelAlert;
+use App\Models\PanelAlertRule;
+
+/**
+ * Configuración de audiencia para alertas (panel, reglas de panel, reglas de sistema).
+ */
+final readonly class AlertAudienceDto
+{
+    public function __construct(
+        public bool $notifyAll,
+        public ?string $audienceKind,
+        public ?string $academicLevel,
+        public ?string $audienceStudyTypeId,
+        public ?string $audienceStudyId,
+        public ?string $audienceModuleId,
+        public ?string $audienceTeamId,
+    ) {}
+
+    public static function fromModel(PanelAlert|PanelAlertRule|AlertRule $model): self
+    {
+        return self::fromArray($model->getAttributes());
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            notifyAll: (bool) ($data['notify_all'] ?? true),
+            audienceKind: isset($data['audience_kind']) ? (string) $data['audience_kind'] : null,
+            academicLevel: isset($data['academic_level']) ? (string) $data['academic_level'] : null,
+            audienceStudyTypeId: isset($data['audience_study_type_id']) ? (string) $data['audience_study_type_id'] : null,
+            audienceStudyId: isset($data['audience_study_id']) ? (string) $data['audience_study_id'] : null,
+            audienceModuleId: isset($data['audience_module_id']) ? (string) $data['audience_module_id'] : null,
+            audienceTeamId: isset($data['audience_team_id']) ? (string) $data['audience_team_id'] : null,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toPersistenceArray(): array
+    {
+        return [
+            'notify_all' => $this->notifyAll,
+            'audience_kind' => $this->audienceKind,
+            'academic_level' => $this->academicLevel,
+            'audience_study_type_id' => $this->audienceStudyTypeId,
+            'audience_study_id' => $this->audienceStudyId,
+            'audience_module_id' => $this->audienceModuleId,
+            'audience_team_id' => $this->audienceTeamId,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toApiArray(): array
+    {
+        return $this->toPersistenceArray();
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     */
+    public static function fromValidatedInput(array $input): self
+    {
+        $notifyAll = (bool) ($input['notify_all'] ?? true);
+
+        if ($notifyAll) {
+            return new self(
+                notifyAll: true,
+                audienceKind: null,
+                academicLevel: null,
+                audienceStudyTypeId: null,
+                audienceStudyId: null,
+                audienceModuleId: null,
+                audienceTeamId: null,
+            );
+        }
+
+        $kind = (string) $input['audience_kind'];
+
+        if ($kind === 'team') {
+            return new self(
+                notifyAll: false,
+                audienceKind: 'team',
+                academicLevel: null,
+                audienceStudyTypeId: null,
+                audienceStudyId: null,
+                audienceModuleId: null,
+                audienceTeamId: (string) $input['audience_team_id'],
+            );
+        }
+
+        $level = (string) $input['academic_level'];
+
+        return new self(
+            notifyAll: false,
+            audienceKind: 'academic',
+            academicLevel: $level,
+            audienceStudyTypeId: (string) $input['audience_study_type_id'],
+            audienceStudyId: match ($level) {
+                'study', 'module' => (string) $input['audience_study_id'],
+                default => null,
+            },
+            audienceModuleId: $level === 'module' ? (string) $input['audience_module_id'] : null,
+            audienceTeamId: null,
+        );
+    }
+}

--- a/backend/app/DTOs/AlertRuleDto.php
+++ b/backend/app/DTOs/AlertRuleDto.php
@@ -24,6 +24,7 @@ final readonly class AlertRuleDto
         public ?string $lastEvaluatedAt,
         public ?string $createdAt,
         public ?string $updatedAt,
+        public AlertAudienceDto $audience,
     ) {}
 
     public static function fromModel(AlertRule $m): self
@@ -41,6 +42,7 @@ final readonly class AlertRuleDto
             lastEvaluatedAt: $m->last_evaluated_at?->toIso8601String(),
             createdAt: $m->created_at?->toIso8601String(),
             updatedAt: $m->updated_at?->toIso8601String(),
+            audience: AlertAudienceDto::fromModel($m),
         );
     }
 }

--- a/backend/app/DTOs/PanelAlertDto.php
+++ b/backend/app/DTOs/PanelAlertDto.php
@@ -21,6 +21,7 @@ final readonly class PanelAlertDto
         public string $createdBy,
         public string $createdAt,
         public string $updatedAt,
+        public AlertAudienceDto $audience,
     ) {}
 
     public static function fromModel(PanelAlert $m): self
@@ -38,6 +39,7 @@ final readonly class PanelAlertDto
             createdBy: (string) $m->created_by,
             createdAt: $m->created_at?->toIso8601String() ?? '',
             updatedAt: $m->updated_at?->toIso8601String() ?? '',
+            audience: AlertAudienceDto::fromModel($m),
         );
     }
 }

--- a/backend/app/DTOs/PanelAlertRuleDto.php
+++ b/backend/app/DTOs/PanelAlertRuleDto.php
@@ -28,6 +28,7 @@ final readonly class PanelAlertRuleDto
         public string $createdBy,
         public string $createdAt,
         public string $updatedAt,
+        public AlertAudienceDto $audience,
     ) {}
 
     public static function fromModel(PanelAlertRule $m): self
@@ -49,6 +50,7 @@ final readonly class PanelAlertRuleDto
             createdBy: (string) $m->created_by,
             createdAt: $m->created_at?->toIso8601String() ?? '',
             updatedAt: $m->updated_at?->toIso8601String() ?? '',
+            audience: AlertAudienceDto::fromModel($m),
         );
     }
 }

--- a/backend/app/Http/Controllers/Api/V1/Alerts/AlertRuleController.php
+++ b/backend/app/Http/Controllers/Api/V1/Alerts/AlertRuleController.php
@@ -12,10 +12,12 @@ use App\Http\Resources\AlertRuleResource;
 use App\Services\Contracts\AlertRuleServiceInterface;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Maya\Auth\Concerns\ResolvesKeycloakUser;
 use Maya\Http\Concerns\RespondsWithEnvelope;
 
 class AlertRuleController extends Controller
 {
+    use ResolvesKeycloakUser;
     use RespondsWithEnvelope;
 
     public function __construct(
@@ -39,7 +41,10 @@ class AlertRuleController extends Controller
     public function store(StoreAlertRuleRequest $request): JsonResponse
     {
         return response()->json(
-            (new AlertRuleResource($this->rules->create($request->validated())))->resolve($request),
+            (new AlertRuleResource($this->rules->create(
+                $request->validated(),
+                (string) $this->resolveKeycloakUser($request)->id,
+            )))->resolve($request),
             201,
         );
     }
@@ -48,7 +53,11 @@ class AlertRuleController extends Controller
     {
         return response()->json(
             (new AlertRuleResource(
-                $this->rules->update($ruleId, $request->validated()),
+                $this->rules->update(
+                    $ruleId,
+                    $request->validated(),
+                    (string) $this->resolveKeycloakUser($request)->id,
+                ),
             ))->resolve($request),
         );
     }

--- a/backend/app/Http/Controllers/Api/V1/PanelAlerts/PanelAlertController.php
+++ b/backend/app/Http/Controllers/Api/V1/PanelAlerts/PanelAlertController.php
@@ -40,9 +40,11 @@ class PanelAlertController extends Controller
 
     public function activeForWidget(Request $request): JsonResponse
     {
+        $userId = (string) $this->resolveKeycloakUser($request)->id;
+
         $alerts = array_map(
             fn ($dto) => (new PanelAlertResource($dto))->resolve($request),
-            $this->panelAlerts->activeForWidget(20),
+            $this->panelAlerts->activeForWidget(20, $userId),
         );
 
         return $this->okData(['alerts' => $alerts]);
@@ -64,7 +66,9 @@ class PanelAlertController extends Controller
 
     public function update(UpdatePanelAlertRequest $request, int $id): JsonResponse
     {
-        $dto = $this->panelAlerts->update($id, $request->validated());
+        $updatedBy = (string) $this->resolveKeycloakUser($request)->id;
+
+        $dto = $this->panelAlerts->update($id, $request->validated(), $updatedBy);
 
         return $this->okData(new PanelAlertResource($dto));
     }

--- a/backend/app/Http/Controllers/Api/V1/PanelAlerts/PanelAlertRuleController.php
+++ b/backend/app/Http/Controllers/Api/V1/PanelAlerts/PanelAlertRuleController.php
@@ -49,7 +49,9 @@ class PanelAlertRuleController extends Controller
 
     public function update(UpdatePanelAlertRuleRequest $request, int $id): JsonResponse
     {
-        $dto = $this->panelAlertRules->update($id, $request->validated());
+        $updatedBy = (string) $this->resolveKeycloakUser($request)->id;
+
+        $dto = $this->panelAlertRules->update($id, $request->validated(), $updatedBy);
 
         return $this->okData(new PanelAlertRuleResource($dto));
     }

--- a/backend/app/Http/Requests/Api/Alerts/StoreAlertRuleRequest.php
+++ b/backend/app/Http/Requests/Api/Alerts/StoreAlertRuleRequest.php
@@ -5,21 +5,28 @@ declare(strict_types=1);
 namespace App\Http\Requests\Api\Alerts;
 
 use App\Http\Requests\Concerns\AuthorizesByPermission;
+use App\Http\Requests\Concerns\ValidatesAlertAudience;
 use App\Rules\SafeAlertQuery;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StoreAlertRuleRequest extends FormRequest
 {
     use AuthorizesByPermission;
+    use ValidatesAlertAudience;
 
     public function authorize(): bool
     {
         return $this->userHasPermission('alerts.manage');
     }
 
+    protected function prepareForValidation(): void
+    {
+        $this->prepareAlertAudienceDefaults();
+    }
+
     public function rules(): array
     {
-        return [
+        return array_merge([
             'slug' => ['required', 'string', 'max:128', 'unique:alert_rules,slug', 'regex:/^[a-z0-9][a-z0-9\-]*$/'],
             'name' => ['required', 'string', 'max:200'],
             'description' => ['nullable', 'string'],
@@ -30,6 +37,6 @@ class StoreAlertRuleRequest extends FormRequest
             'context_template' => ['array'],
             'context_template.sample_columns' => ['sometimes', 'array'],
             'context_template.sample_columns.*' => ['string', 'max:128'],
-        ];
+        ], $this->alertAudienceRules());
     }
 }

--- a/backend/app/Http/Requests/Api/Alerts/UpdateAlertRuleRequest.php
+++ b/backend/app/Http/Requests/Api/Alerts/UpdateAlertRuleRequest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace App\Http\Requests\Api\Alerts;
 
 use App\Http\Requests\Concerns\AuthorizesByPermission;
+use App\Http\Requests\Concerns\ValidatesAlertAudience;
 use App\Rules\SafeAlertQuery;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateAlertRuleRequest extends FormRequest
 {
     use AuthorizesByPermission;
+    use ValidatesAlertAudience;
 
     public function authorize(): bool
     {
@@ -19,7 +21,7 @@ class UpdateAlertRuleRequest extends FormRequest
 
     public function rules(): array
     {
-        return [
+        return array_merge([
             'name' => ['sometimes', 'string', 'max:200'],
             'description' => ['sometimes', 'nullable', 'string'],
             'query_sql' => ['sometimes', 'string', new SafeAlertQuery],
@@ -29,6 +31,6 @@ class UpdateAlertRuleRequest extends FormRequest
             'context_template' => ['sometimes', 'array'],
             'context_template.sample_columns' => ['sometimes', 'array'],
             'context_template.sample_columns.*' => ['string', 'max:128'],
-        ];
+        ], $this->alertAudienceRules());
     }
 }

--- a/backend/app/Http/Requests/Api/PanelAlerts/StorePanelAlertRequest.php
+++ b/backend/app/Http/Requests/Api/PanelAlerts/StorePanelAlertRequest.php
@@ -4,13 +4,21 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Api\PanelAlerts;
 
+use App\Http\Requests\Concerns\ValidatesAlertAudience;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StorePanelAlertRequest extends FormRequest
 {
+    use ValidatesAlertAudience;
+
     public function authorize(): bool
     {
         return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->prepareAlertAudienceDefaults();
     }
 
     /**
@@ -18,13 +26,13 @@ class StorePanelAlertRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
+        return array_merge([
             'text' => ['required', 'string'],
             'severity' => ['required', 'string', 'in:critical,high,medium,low'],
             'action_label' => ['nullable', 'string', 'max:255'],
             'action_url' => ['nullable', 'url', 'max:2048'],
             'visible_from' => ['required', 'date'],
             'visible_until' => ['nullable', 'date', 'after:visible_from'],
-        ];
+        ], $this->alertAudienceRules());
     }
 }

--- a/backend/app/Http/Requests/Api/PanelAlerts/StorePanelAlertRuleRequest.php
+++ b/backend/app/Http/Requests/Api/PanelAlerts/StorePanelAlertRuleRequest.php
@@ -4,13 +4,21 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Api\PanelAlerts;
 
+use App\Http\Requests\Concerns\ValidatesAlertAudience;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StorePanelAlertRuleRequest extends FormRequest
 {
+    use ValidatesAlertAudience;
+
     public function authorize(): bool
     {
         return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->prepareAlertAudienceDefaults();
     }
 
     /**
@@ -18,7 +26,7 @@ class StorePanelAlertRuleRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
+        return array_merge([
             'name' => ['required', 'string', 'max:255'],
             'description' => ['nullable', 'string'],
             'event_type' => ['required', 'string', 'max:255'],
@@ -33,6 +41,6 @@ class StorePanelAlertRuleRequest extends FormRequest
             'visible_duration_hours' => ['nullable', 'integer', 'min:1'],
             'max_frequency_minutes' => ['nullable', 'integer', 'min:1'],
             'is_active' => ['boolean'],
-        ];
+        ], $this->alertAudienceRules());
     }
 }

--- a/backend/app/Http/Requests/Api/PanelAlerts/UpdatePanelAlertRequest.php
+++ b/backend/app/Http/Requests/Api/PanelAlerts/UpdatePanelAlertRequest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Api\PanelAlerts;
 
+use App\Http\Requests\Concerns\ValidatesAlertAudience;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdatePanelAlertRequest extends FormRequest
 {
+    use ValidatesAlertAudience;
+
     public function authorize(): bool
     {
         return true;
@@ -18,13 +21,13 @@ class UpdatePanelAlertRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
+        return array_merge([
             'text' => ['sometimes', 'string'],
             'severity' => ['sometimes', 'string', 'in:critical,high,medium,low'],
             'action_label' => ['sometimes', 'nullable', 'string', 'max:255'],
             'action_url' => ['sometimes', 'nullable', 'url', 'max:2048'],
             'visible_from' => ['sometimes', 'date'],
             'visible_until' => ['sometimes', 'nullable', 'date', 'after:visible_from'],
-        ];
+        ], $this->alertAudienceRules());
     }
 }

--- a/backend/app/Http/Requests/Api/PanelAlerts/UpdatePanelAlertRuleRequest.php
+++ b/backend/app/Http/Requests/Api/PanelAlerts/UpdatePanelAlertRuleRequest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Api\PanelAlerts;
 
+use App\Http\Requests\Concerns\ValidatesAlertAudience;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdatePanelAlertRuleRequest extends FormRequest
 {
+    use ValidatesAlertAudience;
+
     public function authorize(): bool
     {
         return true;
@@ -18,7 +21,7 @@ class UpdatePanelAlertRuleRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
+        return array_merge([
             'name' => ['sometimes', 'string', 'max:255'],
             'description' => ['sometimes', 'nullable', 'string'],
             'event_type' => ['sometimes', 'string', 'max:255'],
@@ -33,6 +36,6 @@ class UpdatePanelAlertRuleRequest extends FormRequest
             'visible_duration_hours' => ['sometimes', 'nullable', 'integer', 'min:1'],
             'max_frequency_minutes' => ['sometimes', 'nullable', 'integer', 'min:1'],
             'is_active' => ['sometimes', 'boolean'],
-        ];
+        ], $this->alertAudienceRules());
     }
 }

--- a/backend/app/Http/Requests/Concerns/ValidatesAlertAudience.php
+++ b/backend/app/Http/Requests/Concerns/ValidatesAlertAudience.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Concerns;
+
+trait ValidatesAlertAudience
+{
+    /**
+     * @return array<string, mixed>
+     */
+    protected function alertAudienceRules(): array
+    {
+        return [
+            'notify_all' => ['boolean'],
+            'audience_kind' => ['required_if:notify_all,false', 'nullable', 'string', 'in:academic,team'],
+            'academic_level' => ['required_if:audience_kind,academic', 'nullable', 'string', 'in:study_type,study,module'],
+            'audience_study_type_id' => ['required_if:audience_kind,academic', 'nullable', 'string', 'max:64'],
+            'audience_study_id' => ['required_if:academic_level,study', 'required_if:academic_level,module', 'nullable', 'string', 'max:64'],
+            'audience_module_id' => ['required_if:academic_level,module', 'nullable', 'string', 'max:64'],
+            'audience_team_id' => ['required_if:audience_kind,team', 'nullable', 'string', 'max:64'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function alertAudienceAttributes(): array
+    {
+        return [
+            'notify_all' => 'enviar a todos',
+            'audience_kind' => 'tipo de audiencia',
+            'academic_level' => 'nivel académico',
+            'audience_study_type_id' => 'tipo de estudio',
+            'audience_study_id' => 'estudio',
+            'audience_module_id' => 'módulo',
+            'audience_team_id' => 'equipo',
+        ];
+    }
+
+    protected function prepareAlertAudienceDefaults(): void
+    {
+        if (! $this->has('notify_all')) {
+            $this->merge(['notify_all' => true]);
+        }
+    }
+}

--- a/backend/app/Http/Resources/AlertRuleResource.php
+++ b/backend/app/Http/Resources/AlertRuleResource.php
@@ -34,6 +34,7 @@ class AlertRuleResource extends JsonResource
             'last_evaluated_at' => $dto->lastEvaluatedAt,
             'created_at' => $dto->createdAt,
             'updated_at' => $dto->updatedAt,
+            ...$dto->audience->toApiArray(),
         ];
     }
 }

--- a/backend/app/Http/Resources/PanelAlertResource.php
+++ b/backend/app/Http/Resources/PanelAlertResource.php
@@ -34,6 +34,7 @@ class PanelAlertResource extends JsonResource
             'created_by' => $dto->createdBy,
             'created_at' => $dto->createdAt,
             'updated_at' => $dto->updatedAt,
+            ...$dto->audience->toApiArray(),
         ];
     }
 }

--- a/backend/app/Http/Resources/PanelAlertRuleResource.php
+++ b/backend/app/Http/Resources/PanelAlertRuleResource.php
@@ -38,6 +38,7 @@ class PanelAlertRuleResource extends JsonResource
             'created_by' => $dto->createdBy,
             'created_at' => $dto->createdAt,
             'updated_at' => $dto->updatedAt,
+            ...$dto->audience->toApiArray(),
         ];
     }
 }

--- a/backend/app/Models/AlertRule.php
+++ b/backend/app/Models/AlertRule.php
@@ -21,6 +21,13 @@ class AlertRule extends Model
         'slug', 'name', 'description', 'query_sql', 'severity',
         'schedule_cron', 'enabled', 'context_template', 'last_evaluated_at',
         'created_by_id',
+        'notify_all',
+        'audience_kind',
+        'academic_level',
+        'audience_study_type_id',
+        'audience_study_id',
+        'audience_module_id',
+        'audience_team_id',
     ];
 
     protected static function booted(): void
@@ -35,6 +42,7 @@ class AlertRule extends Model
     {
         return [
             'enabled' => 'boolean',
+            'notify_all' => 'boolean',
             'context_template' => 'array',
             'last_evaluated_at' => 'datetime',
         ];

--- a/backend/app/Models/PanelAlert.php
+++ b/backend/app/Models/PanelAlert.php
@@ -26,11 +26,19 @@ class PanelAlert extends Model
         'source',
         'rule_id',
         'created_by',
+        'notify_all',
+        'audience_kind',
+        'academic_level',
+        'audience_study_type_id',
+        'audience_study_id',
+        'audience_module_id',
+        'audience_team_id',
     ];
 
     protected function casts(): array
     {
         return [
+            'notify_all' => 'boolean',
             'visible_from' => 'datetime',
             'visible_until' => 'datetime',
             'created_at' => 'datetime',

--- a/backend/app/Models/PanelAlertRule.php
+++ b/backend/app/Models/PanelAlertRule.php
@@ -29,6 +29,13 @@ class PanelAlertRule extends Model
         'is_active',
         'last_triggered_at',
         'created_by',
+        'notify_all',
+        'audience_kind',
+        'academic_level',
+        'audience_study_type_id',
+        'audience_study_id',
+        'audience_module_id',
+        'audience_team_id',
     ];
 
     protected function casts(): array
@@ -36,6 +43,7 @@ class PanelAlertRule extends Model
         return [
             'conditions' => 'array',
             'is_active' => 'boolean',
+            'notify_all' => 'boolean',
             'last_triggered_at' => 'datetime',
             'created_at' => 'datetime',
             'updated_at' => 'datetime',

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Repositories\Contracts\AlertAudienceRepositoryInterface;
 use App\Repositories\Contracts\AlertRepositoryInterface;
 use App\Repositories\Contracts\AlertRuleRepositoryInterface;
 use App\Repositories\Contracts\ApplicationRepositoryInterface;
@@ -15,6 +16,7 @@ use App\Repositories\Contracts\PanelAlertRuleRepositoryInterface;
 use App\Repositories\Contracts\UserDashboardLayoutRepositoryInterface;
 use App\Repositories\Contracts\UserFavoriteApplicationRepositoryInterface;
 use App\Repositories\Contracts\UserRepositoryInterface;
+use App\Repositories\Eloquent\AlertAudienceRepository;
 use App\Repositories\Eloquent\AlertRepository;
 use App\Repositories\Eloquent\AlertRuleRepository;
 use App\Repositories\Eloquent\ApplicationRepository;
@@ -28,14 +30,20 @@ use App\Repositories\Eloquent\UserFavoriteApplicationRepository;
 use App\Repositories\Eloquent\UserRepository;
 use Maya\Profile\Migrations as ProfileMigrations;
 use App\Repositories\Resolvers\DashboardProfileResolver;
+use App\Services\Alerts\AlertAudienceService;
+use App\Services\Alerts\AlertAudienceValidator;
 use App\Services\Alerts\AlertIngestionService;
 use App\Services\Alerts\AlertRuleService;
 use App\Services\Alerts\AlertService;
+use App\Services\Alerts\SystemAlertDispatchService;
 use App\Services\Attendance\AttendanceService;
 use App\Services\Booking\BookingService;
+use App\Services\Contracts\AlertAudienceServiceInterface;
+use App\Services\Contracts\AlertAudienceValidatorInterface;
 use App\Services\Contracts\AlertIngestionServiceInterface;
 use App\Services\Contracts\AlertRuleServiceInterface;
 use App\Services\Contracts\AlertServiceInterface;
+use App\Services\Contracts\SystemAlertDispatchServiceInterface;
 use App\Services\Contracts\ApplicationServiceInterface;
 use App\Services\Contracts\AttendanceServiceInterface;
 use App\Services\Contracts\BookingServiceInterface;
@@ -86,11 +94,15 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton(NotificationIngestionServiceInterface::class, NotificationIngestionService::class);
 
         // Alerts.
+        $this->app->singleton(AlertAudienceRepositoryInterface::class, AlertAudienceRepository::class);
+        $this->app->singleton(AlertAudienceValidatorInterface::class, AlertAudienceValidator::class);
+        $this->app->singleton(AlertAudienceServiceInterface::class, AlertAudienceService::class);
         $this->app->singleton(AlertRepositoryInterface::class, AlertRepository::class);
         $this->app->singleton(AlertRuleRepositoryInterface::class, AlertRuleRepository::class);
         $this->app->singleton(AlertServiceInterface::class, AlertService::class);
         $this->app->singleton(AlertRuleServiceInterface::class, AlertRuleService::class);
         $this->app->singleton(AlertIngestionServiceInterface::class, AlertIngestionService::class);
+        $this->app->singleton(SystemAlertDispatchServiceInterface::class, SystemAlertDispatchService::class);
 
         // Panel Alerts (user-created alerts for dashboard widget).
         $this->app->singleton(PanelAlertRepositoryInterface::class, PanelAlertRepository::class);

--- a/backend/app/Repositories/Contracts/AlertAudienceRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/AlertAudienceRepositoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories\Contracts;
+
+use App\DTOs\AlertAudienceDto;
+use Generator;
+
+interface AlertAudienceRepositoryInterface
+{
+    /**
+     * IDs Keycloak de usuarios activos que pertenecen a la audiencia.
+     *
+     * @return Generator<string>
+     */
+    public function cursorRecipientIdsForAudience(AlertAudienceDto $audience): Generator;
+
+    public function userMatchesAudience(string $userId, AlertAudienceDto $audience): bool;
+}

--- a/backend/app/Repositories/Contracts/PanelAlertRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/PanelAlertRepositoryInterface.php
@@ -27,7 +27,7 @@ interface PanelAlertRepositoryInterface
      *
      * @return Collection<int, PanelAlert>
      */
-    public function activeNow(int $limit): Collection;
+    public function activeNow(int $limit, string $userId): Collection;
 
     public function findOrFail(int $id): PanelAlert;
 

--- a/backend/app/Repositories/Eloquent/AlertAudienceRepository.php
+++ b/backend/app/Repositories/Eloquent/AlertAudienceRepository.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories\Eloquent;
+
+use App\DTOs\AlertAudienceDto;
+use App\Models\User;
+use App\Repositories\Contracts\AlertAudienceRepositoryInterface;
+use Generator;
+use Illuminate\Support\Facades\DB;
+
+final class AlertAudienceRepository implements AlertAudienceRepositoryInterface
+{
+    public function cursorRecipientIdsForAudience(AlertAudienceDto $audience): Generator
+    {
+        if ($audience->notifyAll) {
+            foreach (User::query()->where('is_active', true)->select('id')->cursor() as $user) {
+                yield (string) $user->id;
+            }
+
+            return;
+        }
+
+        $query = User::query()
+            ->where('is_active', true)
+            ->select('users.id');
+
+        $this->applyAudienceConstraint($query, $audience);
+
+        foreach ($query->cursor() as $user) {
+            yield (string) $user->id;
+        }
+    }
+
+    public function userMatchesAudience(string $userId, AlertAudienceDto $audience): bool
+    {
+        if ($audience->notifyAll) {
+            return true;
+        }
+
+        $query = User::query()
+            ->where('is_active', true)
+            ->where('id', $userId);
+
+        $this->applyAudienceConstraint($query, $audience);
+
+        return $query->exists();
+    }
+
+    /**
+     * @param  \Illuminate\Database\Eloquent\Builder<User>  $query
+     */
+    private function applyAudienceConstraint($query, AlertAudienceDto $audience): void
+    {
+        if ($audience->audienceKind === 'team' && $audience->audienceTeamId !== null) {
+            $query->whereExists(function ($sub) use ($audience): void {
+                $sub->select(DB::raw('1'))
+                    ->from('team_members')
+                    ->whereColumn('team_members.user_id', 'users.id')
+                    ->where('team_members.team_id', $audience->audienceTeamId);
+            });
+
+            return;
+        }
+
+        if ($audience->audienceKind !== 'academic') {
+            $query->whereRaw('1 = 0');
+
+            return;
+        }
+
+        match ($audience->academicLevel) {
+            'study_type' => $query->whereExists(function ($sub) use ($audience): void {
+                $sub->select(DB::raw('1'))
+                    ->from('user_study_types')
+                    ->whereColumn('user_study_types.user_id', 'users.id')
+                    ->where('user_study_types.study_type_id', $audience->audienceStudyTypeId);
+            }),
+            'study' => $query->whereExists(function ($sub) use ($audience): void {
+                $sub->select(DB::raw('1'))
+                    ->from('user_studies')
+                    ->whereColumn('user_studies.user_id', 'users.id')
+                    ->where('user_studies.study_id', $audience->audienceStudyId);
+            }),
+            'module' => $query->whereExists(function ($sub) use ($audience): void {
+                $sub->select(DB::raw('1'))
+                    ->from('user_course_modules')
+                    ->whereColumn('user_course_modules.user_id', 'users.id')
+                    ->where('user_course_modules.module_id', $audience->audienceModuleId);
+            }),
+            default => $query->whereRaw('1 = 0'),
+        };
+    }
+}

--- a/backend/app/Repositories/Eloquent/PanelAlertRepository.php
+++ b/backend/app/Repositories/Eloquent/PanelAlertRepository.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace App\Repositories\Eloquent;
 
+use App\DTOs\AlertAudienceDto;
 use App\Models\PanelAlert;
+use App\Repositories\Contracts\AlertAudienceRepositoryInterface;
 use App\Repositories\Contracts\PanelAlertRepositoryInterface;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Collection;
 
 final class PanelAlertRepository implements PanelAlertRepositoryInterface
 {
+    public function __construct(
+        private readonly AlertAudienceRepositoryInterface $audience,
+    ) {}
+
     public function paginate(
         int $perPage,
         ?string $severity,
@@ -45,13 +51,18 @@ final class PanelAlertRepository implements PanelAlertRepositoryInterface
     /**
      * @return Collection<int, PanelAlert>
      */
-    public function activeNow(int $limit): Collection
+    public function activeNow(int $limit, string $userId): Collection
     {
         return PanelAlert::query()
             ->active()
             ->orderByDesc('visible_from')
-            ->limit($limit)
-            ->get();
+            ->limit($limit * 3)
+            ->get()
+            ->filter(function (PanelAlert $alert) use ($userId): bool {
+                return $this->audience->userMatchesAudience($userId, AlertAudienceDto::fromModel($alert));
+            })
+            ->take($limit)
+            ->values();
     }
 
     public function findOrFail(int $id): PanelAlert

--- a/backend/app/Services/Alerts/AlertAudienceService.php
+++ b/backend/app/Services/Alerts/AlertAudienceService.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Alerts;
+
+use App\DTOs\AlertAudienceDto;
+use App\Services\Contracts\AlertAudienceServiceInterface;
+use App\Services\Contracts\AlertAudienceValidatorInterface;
+
+final class AlertAudienceService implements AlertAudienceServiceInterface
+{
+    /** @var list<string> */
+    public const INPUT_KEYS = [
+        'notify_all',
+        'audience_kind',
+        'academic_level',
+        'audience_study_type_id',
+        'audience_study_id',
+        'audience_module_id',
+        'audience_team_id',
+    ];
+
+    public function __construct(
+        private readonly AlertAudienceValidatorInterface $validator,
+    ) {}
+
+    public function attributesForPersist(string $creatorId, array $validated): array
+    {
+        $this->validator->assertCreatorOwnsAudience($creatorId, $validated);
+
+        $content = array_diff_key($validated, array_flip(self::INPUT_KEYS));
+        $audience = AlertAudienceDto::fromValidatedInput($validated)->toPersistenceArray();
+
+        return array_merge($content, $audience);
+    }
+
+    public function attributesForUpdate(string $creatorId, array $validated, AlertAudienceDto $current): array
+    {
+        if (! $this->containsAudienceInput($validated)) {
+            return array_diff_key($validated, array_flip(self::INPUT_KEYS));
+        }
+
+        return $this->attributesForPersist($creatorId, array_merge($current->toApiArray(), $validated));
+    }
+
+    public function containsAudienceInput(array $data): bool
+    {
+        foreach (self::INPUT_KEYS as $key) {
+            if (array_key_exists($key, $data)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/app/Services/Alerts/AlertAudienceValidator.php
+++ b/backend/app/Services/Alerts/AlertAudienceValidator.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Alerts;
+
+use App\Services\Contracts\AlertAudienceValidatorInterface;
+use Illuminate\Validation\ValidationException;
+use Maya\Profile\Dtos\AcademicContextDto;
+use Maya\Profile\Dtos\CourseModuleDto;
+use Maya\Profile\Dtos\StudyDto;
+use Maya\Profile\Dtos\TeamDto;
+use Maya\Profile\Services\Contracts\AcademicContextServiceInterface;
+
+final class AlertAudienceValidator implements AlertAudienceValidatorInterface
+{
+    public function __construct(
+        private readonly AcademicContextServiceInterface $academicContext,
+    ) {}
+
+    public function assertCreatorOwnsAudience(string $creatorId, array $audienceInput): void
+    {
+        if ((bool) ($audienceInput['notify_all'] ?? true)) {
+            return;
+        }
+
+        $context = $this->academicContext->forUser($creatorId);
+        $kind = (string) $audienceInput['audience_kind'];
+
+        if ($kind === 'team') {
+            $this->assertTeamOwned($context, (string) $audienceInput['audience_team_id']);
+
+            return;
+        }
+
+        $this->assertAcademicOwned($context, $audienceInput);
+    }
+
+    private function assertTeamOwned(AcademicContextDto $context, string $teamId): void
+    {
+        if ($context->status['teams'] !== 'ok') {
+            throw ValidationException::withMessages([
+                'audience_team_id' => ['El contexto de equipos no está disponible.'],
+            ]);
+        }
+
+        foreach ($context->teams as $team) {
+            if ($team->id === $teamId) {
+                return;
+            }
+        }
+
+        throw ValidationException::withMessages([
+            'audience_team_id' => ['El equipo seleccionado no pertenece a tu contexto.'],
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     */
+    private function assertAcademicOwned(AcademicContextDto $context, array $input): void
+    {
+        $level = (string) $input['academic_level'];
+        $studyTypeId = (string) $input['audience_study_type_id'];
+
+        $this->assertStudyTypeOwned($context, $studyTypeId);
+
+        if ($level === 'study_type') {
+            return;
+        }
+
+        $studyId = (string) $input['audience_study_id'];
+        $study = $this->findStudy($context, $studyId);
+
+        if ($study === null || $study->studyTypeId !== $studyTypeId) {
+            throw ValidationException::withMessages([
+                'audience_study_id' => ['El estudio no pertenece al tipo de estudio seleccionado.'],
+            ]);
+        }
+
+        if ($level === 'study') {
+            return;
+        }
+
+        $moduleId = (string) $input['audience_module_id'];
+        $module = $this->findModule($context, $moduleId);
+
+        if ($module === null || $module->studyId !== $studyId) {
+            throw ValidationException::withMessages([
+                'audience_module_id' => ['El módulo no pertenece al estudio seleccionado.'],
+            ]);
+        }
+    }
+
+    private function assertStudyTypeOwned(AcademicContextDto $context, string $studyTypeId): void
+    {
+        if ($context->status['study_types'] !== 'ok') {
+            throw ValidationException::withMessages([
+                'audience_study_type_id' => ['El contexto académico no está disponible.'],
+            ]);
+        }
+
+        foreach ($context->studyTypes as $item) {
+            if ($item->id === $studyTypeId) {
+                return;
+            }
+        }
+
+        throw ValidationException::withMessages([
+            'audience_study_type_id' => ['El tipo de estudio no pertenece a tu contexto.'],
+        ]);
+    }
+
+    private function findStudy(AcademicContextDto $context, string $studyId): ?StudyDto
+    {
+        if ($context->status['studies'] !== 'ok') {
+            throw ValidationException::withMessages([
+                'audience_study_id' => ['El contexto de estudios no está disponible.'],
+            ]);
+        }
+
+        foreach ($context->studies as $study) {
+            if ($study->id === $studyId) {
+                return $study;
+            }
+        }
+
+        return null;
+    }
+
+    private function findModule(AcademicContextDto $context, string $moduleId): ?CourseModuleDto
+    {
+        if ($context->status['modules'] !== 'ok') {
+            throw ValidationException::withMessages([
+                'audience_module_id' => ['El contexto de módulos no está disponible.'],
+            ]);
+        }
+
+        foreach ($context->modules as $module) {
+            if ($module->id === $moduleId) {
+                return $module;
+            }
+        }
+
+        return null;
+    }
+}

--- a/backend/app/Services/Alerts/AlertRuleService.php
+++ b/backend/app/Services/Alerts/AlertRuleService.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace App\Services\Alerts;
 
+use App\DTOs\AlertAudienceDto;
 use App\DTOs\AlertRuleDto;
 use App\DTOs\AlertRuleFilterDto;
 use App\Models\AlertRule;
 use App\Repositories\Contracts\AlertRuleRepositoryInterface;
+use App\Services\Contracts\AlertAudienceServiceInterface;
 use App\Services\Contracts\AlertRuleServiceInterface;
 use Maya\Http\Pagination\PaginatedDto;
 
@@ -15,6 +17,7 @@ final class AlertRuleService implements AlertRuleServiceInterface
 {
     public function __construct(
         private readonly AlertRuleRepositoryInterface $rules,
+        private readonly AlertAudienceServiceInterface $audience,
     ) {}
 
     /**
@@ -33,17 +36,25 @@ final class AlertRuleService implements AlertRuleServiceInterface
         return AlertRuleDto::fromModel($this->rules->findOrFail($ruleId));
     }
 
-    public function create(array $attributes): AlertRuleDto
+    public function create(array $attributes, string $createdBy): AlertRuleDto
     {
-        return AlertRuleDto::fromModel($this->rules->create($attributes));
+        $payload = $this->audience->attributesForPersist($createdBy, $attributes);
+
+        return AlertRuleDto::fromModel($this->rules->create(array_merge($payload, [
+            'created_by_id' => $createdBy,
+        ])));
     }
 
-    public function update(int $ruleId, array $attributes): AlertRuleDto
+    public function update(int $ruleId, array $attributes, string $updatedBy): AlertRuleDto
     {
-        return AlertRuleDto::fromModel($this->rules->update(
-            $this->rules->findOrFail($ruleId),
+        $rule = $this->rules->findOrFail($ruleId);
+        $payload = $this->audience->attributesForUpdate(
+            $updatedBy,
             $attributes,
-        ));
+            AlertAudienceDto::fromModel($rule),
+        );
+
+        return AlertRuleDto::fromModel($this->rules->update($rule, $payload));
     }
 
     public function delete(int $ruleId): void

--- a/backend/app/Services/Alerts/SystemAlertDispatchService.php
+++ b/backend/app/Services/Alerts/SystemAlertDispatchService.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Alerts;
+
+use App\DTOs\AlertAudienceDto;
+use App\Models\AlertRule;
+use App\Repositories\Contracts\AlertAudienceRepositoryInterface;
+use App\Services\Contracts\SystemAlertDispatchServiceInterface;
+use Maya\Messaging\Publishers\AlertPublisher;
+
+final class SystemAlertDispatchService implements SystemAlertDispatchServiceInterface
+{
+    public function __construct(
+        private readonly AlertPublisher $publisher,
+        private readonly AlertAudienceRepositoryInterface $audience,
+    ) {}
+
+    public function dispatchTriggeredRule(AlertRule $rule, array $context): void
+    {
+        $audience = AlertAudienceDto::fromModel($rule);
+        $recipientIds = [];
+
+        if (! $audience->notifyAll) {
+            foreach ($this->audience->cursorRecipientIdsForAudience($audience) as $recipientId) {
+                $recipientIds[] = $recipientId;
+            }
+        }
+
+        $this->publisher->publish(
+            ruleSlug: (string) $rule->slug,
+            severity: (string) $rule->severity,
+            title: (string) $rule->name,
+            context: $context,
+            source: 'logs.aggregation',
+            notifyAll: $audience->notifyAll,
+            recipientIds: $recipientIds,
+        );
+    }
+}

--- a/backend/app/Services/Contracts/AlertAudienceServiceInterface.php
+++ b/backend/app/Services/Contracts/AlertAudienceServiceInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Contracts;
+
+use App\DTOs\AlertAudienceDto;
+
+interface AlertAudienceServiceInterface
+{
+    /**
+     * Valida pertenencia del creador y devuelve atributos listos para persistir
+     * (contenido de la alerta/regla + columnas de audiencia).
+     *
+     * @param  array<string, mixed>  $validated
+     * @return array<string, mixed>
+     */
+    public function attributesForPersist(string $creatorId, array $validated): array;
+
+    /**
+     * Actualización: fusiona audiencia actual con el payload y valida solo si
+     * el request incluye campos de targeting.
+     *
+     * @param  array<string, mixed>  $validated
+     * @return array<string, mixed>
+     */
+    public function attributesForUpdate(string $creatorId, array $validated, AlertAudienceDto $current): array;
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function containsAudienceInput(array $data): bool;
+}

--- a/backend/app/Services/Contracts/AlertAudienceValidatorInterface.php
+++ b/backend/app/Services/Contracts/AlertAudienceValidatorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Contracts;
+
+interface AlertAudienceValidatorInterface
+{
+    /**
+     * @param  array<string, mixed>  $audienceInput  Campos de audiencia ya validados por FormRequest
+     */
+    public function assertCreatorOwnsAudience(string $creatorId, array $audienceInput): void;
+}

--- a/backend/app/Services/Contracts/AlertRuleServiceInterface.php
+++ b/backend/app/Services/Contracts/AlertRuleServiceInterface.php
@@ -20,12 +20,12 @@ interface AlertRuleServiceInterface
     /**
      * @param  array<string, mixed>  $attributes
      */
-    public function create(array $attributes): AlertRuleDto;
+    public function create(array $attributes, string $createdBy): AlertRuleDto;
 
     /**
      * @param  array<string, mixed>  $attributes
      */
-    public function update(int $ruleId, array $attributes): AlertRuleDto;
+    public function update(int $ruleId, array $attributes, string $updatedBy): AlertRuleDto;
 
     public function delete(int $ruleId): void;
 }

--- a/backend/app/Services/Contracts/PanelAlertRuleServiceInterface.php
+++ b/backend/app/Services/Contracts/PanelAlertRuleServiceInterface.php
@@ -24,7 +24,7 @@ interface PanelAlertRuleServiceInterface
     /**
      * @param  array<string, mixed>  $data
      */
-    public function update(int $id, array $data): PanelAlertRuleDto;
+    public function update(int $id, array $data, string $updatedBy): PanelAlertRuleDto;
 
     public function delete(int $id): void;
 }

--- a/backend/app/Services/Contracts/PanelAlertServiceInterface.php
+++ b/backend/app/Services/Contracts/PanelAlertServiceInterface.php
@@ -26,7 +26,7 @@ interface PanelAlertServiceInterface
      *
      * @return list<PanelAlertDto>
      */
-    public function activeForWidget(int $limit): array;
+    public function activeForWidget(int $limit, string $userId): array;
 
     public function find(int $id): PanelAlertDto;
 
@@ -38,7 +38,7 @@ interface PanelAlertServiceInterface
     /**
      * @param  array<string, mixed>  $data
      */
-    public function update(int $id, array $data): PanelAlertDto;
+    public function update(int $id, array $data, string $updatedBy): PanelAlertDto;
 
     public function delete(int $id): void;
 }

--- a/backend/app/Services/Contracts/SystemAlertDispatchServiceInterface.php
+++ b/backend/app/Services/Contracts/SystemAlertDispatchServiceInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Contracts;
+
+use App\Models\AlertRule;
+
+interface SystemAlertDispatchServiceInterface
+{
+    /**
+     * Publica la alerta de sistema (AMQP + notificaciones según audiencia de la regla).
+     *
+     * @param  array<string, mixed>  $context
+     */
+    public function dispatchTriggeredRule(AlertRule $rule, array $context): void;
+}

--- a/backend/app/Services/PanelAlerts/PanelAlertNotificationService.php
+++ b/backend/app/Services/PanelAlerts/PanelAlertNotificationService.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace App\Services\PanelAlerts;
 
+use App\DTOs\AlertAudienceDto;
 use App\Models\PanelAlert;
-use App\Repositories\Contracts\UserRepositoryInterface;
+use App\Repositories\Contracts\AlertAudienceRepositoryInterface;
 use App\Services\Contracts\PanelAlertNotificationServiceInterface;
 use Illuminate\Support\Str;
 use Maya\Messaging\Publishers\NotificationPublisher;
@@ -19,7 +20,7 @@ final class PanelAlertNotificationService implements PanelAlertNotificationServi
     public function __construct(
         private readonly NotificationPublisher $notificationPublisher,
         private readonly ResilientLogPublisher $resilientLogPublisher,
-        private readonly UserRepositoryInterface $users,
+        private readonly AlertAudienceRepositoryInterface $audience,
     ) {}
 
     private function messagingAppSlug(): string
@@ -47,11 +48,13 @@ final class PanelAlertNotificationService implements PanelAlertNotificationServi
 
         $recipientCount = 0;
 
-        foreach ($this->users->cursorActive() as $user) {
+        $audienceConfig = AlertAudienceDto::fromModel($alert);
+
+        foreach ($this->audience->cursorRecipientIdsForAudience($audienceConfig) as $recipientId) {
             try {
                 $this->notificationPublisher->send(
                     type: $type,
-                    recipientId: $user->id,
+                    recipientId: $recipientId,
                     title: $title,
                     body: $alert->text,
                     channels: ['app'],
@@ -69,7 +72,7 @@ final class PanelAlertNotificationService implements PanelAlertNotificationServi
                     [
                         'type' => $type,
                         'panel_alert_id' => $alert->id,
-                        'recipient_keycloak_id' => $user->id,
+                        'recipient_keycloak_id' => $recipientId,
                     ],
                     $this->messagingAppSlug(),
                 );

--- a/backend/app/Services/PanelAlerts/PanelAlertRuleService.php
+++ b/backend/app/Services/PanelAlerts/PanelAlertRuleService.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Services\PanelAlerts;
 
+use App\DTOs\AlertAudienceDto;
 use App\DTOs\PanelAlertRuleDto;
 use App\Models\PanelAlertRule;
 use App\Repositories\Contracts\PanelAlertRuleRepositoryInterface;
+use App\Services\Contracts\AlertAudienceServiceInterface;
 use App\Services\Contracts\PanelAlertRuleServiceInterface;
 use Maya\Http\Pagination\PaginatedDto;
 
@@ -14,6 +16,7 @@ final class PanelAlertRuleService implements PanelAlertRuleServiceInterface
 {
     public function __construct(
         private readonly PanelAlertRuleRepositoryInterface $rules,
+        private readonly AlertAudienceServiceInterface $audience,
     ) {}
 
     /**
@@ -34,15 +37,24 @@ final class PanelAlertRuleService implements PanelAlertRuleServiceInterface
 
     public function create(array $data, string $createdBy): PanelAlertRuleDto
     {
+        $attributes = $this->audience->attributesForPersist($createdBy, $data);
+
         return PanelAlertRuleDto::fromModel(
-            $this->rules->create(array_merge($data, ['created_by' => $createdBy])),
+            $this->rules->create(array_merge($attributes, ['created_by' => $createdBy])),
         );
     }
 
-    public function update(int $id, array $data): PanelAlertRuleDto
+    public function update(int $id, array $data, string $updatedBy): PanelAlertRuleDto
     {
+        $rule = $this->rules->findOrFail($id);
+        $attributes = $this->audience->attributesForUpdate(
+            $updatedBy,
+            $data,
+            AlertAudienceDto::fromModel($rule),
+        );
+
         return PanelAlertRuleDto::fromModel(
-            $this->rules->update($this->rules->findOrFail($id), $data),
+            $this->rules->update($rule, $attributes),
         );
     }
 

--- a/backend/app/Services/PanelAlerts/PanelAlertService.php
+++ b/backend/app/Services/PanelAlerts/PanelAlertService.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Services\PanelAlerts;
 
+use App\DTOs\AlertAudienceDto;
 use App\DTOs\PanelAlertDto;
 use App\Models\PanelAlert;
 use App\Repositories\Contracts\PanelAlertRepositoryInterface;
+use App\Services\Contracts\AlertAudienceServiceInterface;
 use App\Services\Contracts\PanelAlertServiceInterface;
 use Maya\Http\Pagination\PaginatedDto;
 
@@ -14,6 +16,7 @@ final class PanelAlertService implements PanelAlertServiceInterface
 {
     public function __construct(
         private readonly PanelAlertRepositoryInterface $alerts,
+        private readonly AlertAudienceServiceInterface $audience,
     ) {}
 
     /**
@@ -38,9 +41,9 @@ final class PanelAlertService implements PanelAlertServiceInterface
     /**
      * @return list<PanelAlertDto>
      */
-    public function activeForWidget(int $limit): array
+    public function activeForWidget(int $limit, string $userId): array
     {
-        return $this->alerts->activeNow($limit)
+        return $this->alerts->activeNow($limit, $userId)
             ->map(fn (PanelAlert $alert): PanelAlertDto => PanelAlertDto::fromModel($alert))
             ->values()
             ->all();
@@ -53,15 +56,24 @@ final class PanelAlertService implements PanelAlertServiceInterface
 
     public function create(array $data, string $createdBy): PanelAlertDto
     {
+        $attributes = $this->audience->attributesForPersist($createdBy, $data);
+
         return PanelAlertDto::fromModel(
-            $this->alerts->create(array_merge($data, ['created_by' => $createdBy])),
+            $this->alerts->create(array_merge($attributes, ['created_by' => $createdBy])),
         );
     }
 
-    public function update(int $id, array $data): PanelAlertDto
+    public function update(int $id, array $data, string $updatedBy): PanelAlertDto
     {
+        $alert = $this->alerts->findOrFail($id);
+        $attributes = $this->audience->attributesForUpdate(
+            $updatedBy,
+            $data,
+            AlertAudienceDto::fromModel($alert),
+        );
+
         return PanelAlertDto::fromModel(
-            $this->alerts->update($this->alerts->findOrFail($id), $data),
+            $this->alerts->update($alert, $attributes),
         );
     }
 

--- a/backend/database/factories/PanelAlertFactory.php
+++ b/backend/database/factories/PanelAlertFactory.php
@@ -27,6 +27,7 @@ class PanelAlertFactory extends Factory
             'source' => 'manual',
             'rule_id' => null,
             'created_by' => (string) Str::uuid(),
+            'notify_all' => true,
         ];
     }
 

--- a/backend/database/factories/PanelAlertRuleFactory.php
+++ b/backend/database/factories/PanelAlertRuleFactory.php
@@ -31,6 +31,7 @@ class PanelAlertRuleFactory extends Factory
             'is_active' => true,
             'last_triggered_at' => null,
             'created_by' => (string) Str::uuid(),
+            'notify_all' => true,
         ];
     }
 

--- a/backend/database/migrations/2026_04_24_000002_create_alert_rules_table.php
+++ b/backend/database/migrations/2026_04_24_000002_create_alert_rules_table.php
@@ -19,6 +19,13 @@ return new class extends Migration
             $table->boolean('enabled')->default(true);
             $table->jsonb('context_template')->nullable()->comment('Static keys merged into alert context');
             $table->timestampTz('last_evaluated_at')->nullable();
+            $table->boolean('notify_all')->default(true);
+            $table->string('audience_kind', 20)->nullable()->comment('academic | team');
+            $table->string('academic_level', 20)->nullable()->comment('study_type | study | module');
+            $table->string('audience_study_type_id', 64)->nullable();
+            $table->string('audience_study_id', 64)->nullable();
+            $table->string('audience_module_id', 64)->nullable();
+            $table->string('audience_team_id', 64)->nullable();
             $table->timestampsTz();
 
             $table->index(['enabled', 'last_evaluated_at']);

--- a/backend/database/migrations/2026_05_27_000001_create_panel_alerts_tables.php
+++ b/backend/database/migrations/2026_05_27_000001_create_panel_alerts_tables.php
@@ -23,6 +23,13 @@ return new class extends Migration
             $table->boolean('is_active')->default(true);
             $table->timestampTz('last_triggered_at')->nullable();
             $table->string('created_by', 255)->comment('Keycloak UUID');
+            $table->boolean('notify_all')->default(true);
+            $table->string('audience_kind', 20)->nullable()->comment('academic | team');
+            $table->string('academic_level', 20)->nullable()->comment('study_type | study | module');
+            $table->string('audience_study_type_id', 64)->nullable();
+            $table->string('audience_study_id', 64)->nullable();
+            $table->string('audience_module_id', 64)->nullable();
+            $table->string('audience_team_id', 64)->nullable();
             $table->timestampsTz();
         });
 
@@ -40,6 +47,13 @@ return new class extends Migration
                 ->constrained('panel_alert_rules')
                 ->nullOnDelete();
             $table->string('created_by', 255)->comment('Keycloak UUID');
+            $table->boolean('notify_all')->default(true);
+            $table->string('audience_kind', 20)->nullable()->comment('academic | team');
+            $table->string('academic_level', 20)->nullable()->comment('study_type | study | module');
+            $table->string('audience_study_type_id', 64)->nullable();
+            $table->string('audience_study_id', 64)->nullable();
+            $table->string('audience_module_id', 64)->nullable();
+            $table->string('audience_team_id', 64)->nullable();
             $table->timestampsTz();
 
             $table->index(['visible_from', 'visible_until']);

--- a/backend/tests/Unit/Services/PanelAlertNotificationServiceTest.php
+++ b/backend/tests/Unit/Services/PanelAlertNotificationServiceTest.php
@@ -2,7 +2,7 @@
 
 use App\Models\PanelAlert;
 use App\Models\User;
-use App\Repositories\Contracts\UserRepositoryInterface;
+use App\Repositories\Contracts\AlertAudienceRepositoryInterface;
 use App\Services\PanelAlerts\PanelAlertNotificationService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
@@ -26,23 +26,24 @@ it('notifies every active user when a panel alert is created', function () {
         'visible_from' => now(),
         'source' => 'manual',
         'created_by' => $userA,
+        'notify_all' => true,
     ]);
 
     $notificationPublisher = Mockery::mock(NotificationPublisher::class);
     $notificationPublisher->shouldReceive('send')->twice();
 
-    $users = Mockery::mock(UserRepositoryInterface::class);
-    $users->shouldReceive('cursorActive')->once()->andReturn(
+    $audience = Mockery::mock(AlertAudienceRepositoryInterface::class);
+    $audience->shouldReceive('cursorRecipientIdsForAudience')->once()->andReturn(
         (function () use ($userA, $userB) {
-            yield new User(['id' => $userA]);
-            yield new User(['id' => $userB]);
+            yield $userA;
+            yield $userB;
         })(),
     );
 
     $service = new PanelAlertNotificationService(
         $notificationPublisher,
         new ResilientLogPublisher(Mockery::mock(LogPublisher::class)->shouldIgnoreMissing()),
-        $users,
+        $audience,
     );
 
     expect($service->notifyUsersOfNewAlert($alert))->toBe(2);
@@ -57,6 +58,7 @@ it('uses panel_alert.rule type for rule-sourced alerts', function () {
         'visible_from' => now(),
         'source' => 'rule',
         'created_by' => $userId,
+        'notify_all' => true,
     ]);
 
     $notificationPublisher = Mockery::mock(NotificationPublisher::class);
@@ -77,17 +79,17 @@ it('uses panel_alert.rule type for rule-sourced alerts', function () {
             && $isCritical === false
             && $recipientId === $userId);
 
-    $users = Mockery::mock(UserRepositoryInterface::class);
-    $users->shouldReceive('cursorActive')->once()->andReturn(
+    $audience = Mockery::mock(AlertAudienceRepositoryInterface::class);
+    $audience->shouldReceive('cursorRecipientIdsForAudience')->once()->andReturn(
         (function () use ($userId) {
-            yield new User(['id' => $userId]);
+            yield $userId;
         })(),
     );
 
     $service = new PanelAlertNotificationService(
         $notificationPublisher,
         new ResilientLogPublisher(Mockery::mock(LogPublisher::class)->shouldIgnoreMissing()),
-        $users,
+        $audience,
     );
 
     expect($service->notifyUsersOfNewAlert($alert))->toBe(1);
@@ -102,6 +104,7 @@ it('publishes structured log to maya.logs when notification publish fails for a 
         'visible_from' => now(),
         'source' => 'manual',
         'created_by' => $userId,
+        'notify_all' => true,
     ]);
 
     $notificationPublisher = Mockery::mock(NotificationPublisher::class);
@@ -130,17 +133,17 @@ it('publishes structured log to maya.logs when notification publish fails for a 
                 && $metadata['type'] === 'panel_alert.manual';
         });
 
-    $users = Mockery::mock(UserRepositoryInterface::class);
-    $users->shouldReceive('cursorActive')->once()->andReturn(
+    $audience = Mockery::mock(AlertAudienceRepositoryInterface::class);
+    $audience->shouldReceive('cursorRecipientIdsForAudience')->once()->andReturn(
         (function () use ($userId) {
-            yield new User(['id' => $userId]);
+            yield $userId;
         })(),
     );
 
     $service = new PanelAlertNotificationService(
         $notificationPublisher,
         new ResilientLogPublisher($logPublisher),
-        $users,
+        $audience,
     );
 
     expect($service->notifyUsersOfNewAlert($alert))->toBe(0);

--- a/frontend/src/features/panel-alerts/components/AlertAudienceFields.tsx
+++ b/frontend/src/features/panel-alerts/components/AlertAudienceFields.tsx
@@ -1,0 +1,282 @@
+import { useMemo } from 'react'
+import { Checkbox, Select } from '@ceedcv-maya/shared-ui-react'
+import { useLocale } from '@ceedcv-maya/shared-i18n-react'
+import { useMyAcademicContext } from '../../profile/api/academicContextApi'
+import type { AcademicLevel, AlertAudienceFormState, AudienceKind } from '../types/alertAudience'
+
+interface Props {
+  value: AlertAudienceFormState
+  onChange: (value: AlertAudienceFormState) => void
+  disabled?: boolean
+}
+
+export function AlertAudienceFields({ value, onChange, disabled }: Props) {
+  const { t } = useLocale()
+  const { data: context, isLoading, error } = useMyAcademicContext()
+
+  const teams = context?.teams ?? []
+  const studyTypes = context?.study_types ?? []
+
+  /** Cascada como en DMS: opciones solo del padre seleccionado. */
+  const studiesForType = useMemo(() => {
+    if (!value.audience_study_type_id) return []
+    return (context?.studies ?? []).filter(
+      (s) => s.study_type_id === value.audience_study_type_id,
+    )
+  }, [context?.studies, value.audience_study_type_id])
+
+  const modulesForStudy = useMemo(() => {
+    if (!value.audience_study_id) return []
+    return (context?.modules ?? []).filter((m) => m.study_id === value.audience_study_id)
+  }, [context?.modules, value.audience_study_id])
+
+  const needsStudy =
+    value.academic_level === 'study' || value.academic_level === 'module'
+  const showStudySelect = needsStudy && value.audience_study_type_id !== ''
+  const showModuleSelect =
+    value.academic_level === 'module' && value.audience_study_id !== ''
+
+  const patch = (partial: Partial<AlertAudienceFormState>) => onChange({ ...value, ...partial })
+
+  const handleNotifyAll = (checked: boolean) => {
+    patch({ notify_all: checked })
+  }
+
+  const handleAudienceKind = (kind: AudienceKind) => {
+    onChange({
+      ...value,
+      audience_kind: kind,
+      audience_study_type_id: '',
+      audience_study_id: '',
+      audience_module_id: '',
+      audience_team_id: '',
+    })
+  }
+
+  const handleAcademicLevel = (level: AcademicLevel) => {
+    const next = { ...value, academic_level: level }
+    if (level === 'study_type') {
+      next.audience_study_id = ''
+      next.audience_module_id = ''
+    } else if (level === 'study') {
+      next.audience_module_id = ''
+    }
+    onChange(next)
+  }
+
+  const teamsStatus = context?._status?.teams
+  const teamsUnavailable = teamsStatus === 'unavailable'
+  const noTeamsAssigned =
+    value.audience_kind === 'team' &&
+    !isLoading &&
+    error == null &&
+    !teamsUnavailable &&
+    teams.length === 0
+
+  const contextUnavailable =
+    !value.notify_all &&
+    value.audience_kind === 'academic' &&
+    (isLoading ||
+      error != null ||
+      (context != null && studyTypes.length === 0 && teams.length === 0))
+
+  return (
+    <fieldset className="space-y-3 rounded-lg border border-ui-border p-3 dark:border-ui-dark-border">
+      <legend className="px-1 text-sm font-medium text-text-primary dark:text-text-dark-primary">
+        {t('panelAlerts.audience.sectionTitle')}
+      </legend>
+
+      <Checkbox
+        checked={value.notify_all}
+        onChange={handleNotifyAll}
+        disabled={disabled}
+        label={t('panelAlerts.audience.notifyAll')}
+      />
+
+      {!value.notify_all && (
+        <>
+          {isLoading && (
+            <p className="text-sm text-text-muted dark:text-text-dark-muted">
+              {t('status.loading')}
+            </p>
+          )}
+          {error && (
+            <p role="alert" className="text-sm text-danger">
+              {t('panelAlerts.audience.contextError')}
+            </p>
+          )}
+
+          <div className="flex flex-wrap gap-4">
+            <label className="flex items-center gap-2 cursor-pointer text-sm">
+              <input
+                type="radio"
+                name="audience_kind"
+                checked={value.audience_kind === 'academic'}
+                onChange={() => handleAudienceKind('academic')}
+                disabled={disabled || isLoading}
+              />
+              {t('panelAlerts.audience.kindAcademic')}
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer text-sm">
+              <input
+                type="radio"
+                name="audience_kind"
+                checked={value.audience_kind === 'team'}
+                onChange={() => handleAudienceKind('team')}
+                disabled={disabled || isLoading}
+              />
+              {t('panelAlerts.audience.kindTeam')}
+            </label>
+          </div>
+
+          {value.audience_kind === 'academic' && (
+            <div className="space-y-3">
+              <div>
+                <span className="mb-1 block text-xs font-semibold text-text-secondary dark:text-text-dark-secondary">
+                  {t('panelAlerts.audience.academicLevel')}
+                </span>
+                <div className="flex flex-wrap gap-3">
+                  {(['study_type', 'study', 'module'] as const).map((level) => (
+                    <label key={level} className="flex items-center gap-2 cursor-pointer text-sm">
+                      <input
+                        type="radio"
+                        name="academic_level"
+                        checked={value.academic_level === level}
+                        onChange={() => handleAcademicLevel(level)}
+                        disabled={disabled || isLoading}
+                      />
+                      {t(`panelAlerts.audience.level.${level}`)}
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium text-text-primary dark:text-text-dark-primary">
+                  {t('panelAlerts.audience.studyType')} <span className="text-danger">*</span>
+                </label>
+                <Select
+                  fieldSize="sm"
+                  value={value.audience_study_type_id}
+                  onChange={(e) =>
+                    patch({
+                      audience_study_type_id: e.target.value,
+                      audience_study_id: '',
+                      audience_module_id: '',
+                    })
+                  }
+                  disabled={disabled || isLoading || studyTypes.length === 0}
+                >
+                  <option value="">{t('panelAlerts.audience.selectPlaceholder')}</option>
+                  {studyTypes.map((st) => (
+                    <option key={st.id} value={st.id}>
+                      {st.name} ({st.code})
+                    </option>
+                  ))}
+                </Select>
+              </div>
+
+              {needsStudy && !showStudySelect && (
+                <p className="text-xs text-text-muted dark:text-text-dark-muted">
+                  {t('panelAlerts.audience.selectStudyTypeFirst')}
+                </p>
+              )}
+
+              {showStudySelect && (
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-text-primary dark:text-text-dark-primary">
+                    {t('panelAlerts.audience.study')} <span className="text-danger">*</span>
+                  </label>
+                  <Select
+                    fieldSize="sm"
+                    value={value.audience_study_id}
+                    onChange={(e) =>
+                      patch({ audience_study_id: e.target.value, audience_module_id: '' })
+                    }
+                    disabled={disabled || isLoading || studiesForType.length === 0}
+                  >
+                    <option value="">{t('panelAlerts.audience.selectPlaceholder')}</option>
+                    {studiesForType.map((s) => (
+                      <option key={s.id} value={s.id}>
+                        {s.name} ({s.code})
+                      </option>
+                    ))}
+                  </Select>
+                </div>
+              )}
+
+              {value.academic_level === 'module' && !showModuleSelect && showStudySelect && (
+                <p className="text-xs text-text-muted dark:text-text-dark-muted">
+                  {t('panelAlerts.audience.selectStudyFirst')}
+                </p>
+              )}
+
+              {showModuleSelect && (
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-text-primary dark:text-text-dark-primary">
+                    {t('panelAlerts.audience.module')} <span className="text-danger">*</span>
+                  </label>
+                  <Select
+                    fieldSize="sm"
+                    value={value.audience_module_id}
+                    onChange={(e) => patch({ audience_module_id: e.target.value })}
+                    disabled={disabled || isLoading || modulesForStudy.length === 0}
+                  >
+                    <option value="">{t('panelAlerts.audience.selectPlaceholder')}</option>
+                    {modulesForStudy.map((m) => (
+                      <option key={m.id} value={m.id}>
+                        {m.name} ({m.code})
+                      </option>
+                    ))}
+                  </Select>
+                </div>
+              )}
+            </div>
+          )}
+
+          {value.audience_kind === 'team' && (
+            <div className="space-y-2">
+              {teamsUnavailable && (
+                <p role="alert" className="text-sm text-danger">
+                  {t('panelAlerts.audience.teamsUnavailable')}
+                </p>
+              )}
+              {noTeamsAssigned && (
+                <p className="text-sm text-text-muted dark:text-text-dark-muted">
+                  {t('panelAlerts.audience.noTeamsAssigned')}
+                </p>
+              )}
+              {!teamsUnavailable && teams.length > 0 && (
+                <>
+                  <label className="mb-1 block text-sm font-medium text-text-primary dark:text-text-dark-primary">
+                    {t('panelAlerts.audience.team')} <span className="text-danger">*</span>
+                  </label>
+                  <Select
+                    fieldSize="sm"
+                    value={value.audience_team_id}
+                    onChange={(e) => patch({ audience_team_id: e.target.value })}
+                    disabled={disabled || isLoading}
+                  >
+                    <option value="">{t('panelAlerts.audience.selectPlaceholder')}</option>
+                    {teams.map((team) => (
+                      <option key={team.id} value={team.id}>
+                        {team.name} ({team.code})
+                        {team.is_department ? ` — ${t('panelAlerts.audience.department')}` : ''}
+                      </option>
+                    ))}
+                  </Select>
+                </>
+              )}
+            </div>
+          )}
+
+          {contextUnavailable && !isLoading && !error && (
+            <p className="text-sm text-text-muted dark:text-text-dark-muted">
+              {t('panelAlerts.audience.emptyContext')}
+            </p>
+          )}
+        </>
+      )}
+    </fieldset>
+  )
+}

--- a/frontend/src/features/panel-alerts/components/PanelAlertForm.tsx
+++ b/frontend/src/features/panel-alerts/components/PanelAlertForm.tsx
@@ -2,6 +2,14 @@ import { useEffect, useState } from 'react'
 import { Button, Select, TextInput } from '@ceedcv-maya/shared-ui-react'
 import { MayaEditor } from '@ceedcv-maya/shared-editor-react'
 import { useLocale } from '@ceedcv-maya/shared-i18n-react'
+import { AlertAudienceFields } from './AlertAudienceFields'
+import {
+  audienceFormStateFromApi,
+  buildAudiencePayload,
+  defaultAudienceFormState,
+  validateAudienceForm,
+  type AlertAudienceFormState,
+} from '../types/alertAudience'
 import type { CreatePanelAlertInput, PanelAlert, Severity } from '../types/panelAlert'
 
 interface Props {
@@ -27,10 +35,14 @@ export function PanelAlertForm({ initial, onSubmit, onCancel, loading }: Props) 
   const [actionUrl, setActionUrl] = useState(initial?.action_url ?? '')
   const [visibleFrom, setVisibleFrom] = useState(toDatetimeLocal(initial?.visible_from))
   const [visibleUntil, setVisibleUntil] = useState(toDatetimeLocal(initial?.visible_until))
+  const [audience, setAudience] = useState<AlertAudienceFormState>(() =>
+    initial ? audienceFormStateFromApi(initial) : defaultAudienceFormState(),
+  )
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     if (initial) {
+      setAudience(audienceFormStateFromApi(initial))
       setText(initial.text)
       setSeverity(initial.severity)
       setActionLabel(initial.action_label ?? '')
@@ -45,6 +57,13 @@ export function PanelAlertForm({ initial, onSubmit, onCancel, loading }: Props) 
     setError(null)
     if (!text.trim()) { setError(t('panelAlerts.validation.textRequired')); return }
     if (!visibleFrom) { setError(t('panelAlerts.validation.visibleFromRequired')); return }
+    const audienceError = validateAudienceForm(audience, {
+      teamRequired: t('panelAlerts.validation.teamRequired'),
+      studyTypeRequired: t('panelAlerts.validation.studyTypeRequired'),
+      studyRequired: t('panelAlerts.validation.studyRequired'),
+      moduleRequired: t('panelAlerts.validation.moduleRequired'),
+    })
+    if (audienceError) { setError(audienceError); return }
     try {
       await onSubmit({
         text: text.trim(),
@@ -53,6 +72,7 @@ export function PanelAlertForm({ initial, onSubmit, onCancel, loading }: Props) 
         action_url: actionUrl.trim() || null,
         visible_from: new Date(visibleFrom).toISOString(),
         visible_until: visibleUntil ? new Date(visibleUntil).toISOString() : null,
+        ...buildAudiencePayload(audience),
       })
     } catch (err) {
       setError(err instanceof Error ? err.message : t('panelAlerts.errorSave'))
@@ -108,6 +128,8 @@ export function PanelAlertForm({ initial, onSubmit, onCancel, loading }: Props) 
           />
         </div>
       </div>
+
+      <AlertAudienceFields value={audience} onChange={setAudience} disabled={loading} />
 
       <div className="grid grid-cols-2 gap-3">
         <div>

--- a/frontend/src/features/panel-alerts/components/PanelAlertRuleForm.tsx
+++ b/frontend/src/features/panel-alerts/components/PanelAlertRuleForm.tsx
@@ -2,6 +2,14 @@ import { useEffect, useState } from 'react'
 import { Button, Select, TextInput } from '@ceedcv-maya/shared-ui-react'
 import { MayaEditor } from '@ceedcv-maya/shared-editor-react'
 import { useLocale } from '@ceedcv-maya/shared-i18n-react'
+import { AlertAudienceFields } from './AlertAudienceFields'
+import {
+  audienceFormStateFromApi,
+  buildAudiencePayload,
+  defaultAudienceFormState,
+  validateAudienceForm,
+  type AlertAudienceFormState,
+} from '../types/alertAudience'
 import type { AlertCondition, CreatePanelAlertRuleInput, PanelAlertRule, Severity } from '../types/panelAlert'
 
 interface Props {
@@ -43,12 +51,16 @@ export function PanelAlertRuleForm({ initial, onSubmit, onCancel, loading }: Pro
     initial?.max_frequency_minutes != null ? String(initial.max_frequency_minutes) : '60',
   )
   const [isActive, setIsActive] = useState(initial?.is_active ?? true)
+  const [audience, setAudience] = useState<AlertAudienceFormState>(() =>
+    initial ? audienceFormStateFromApi(initial) : defaultAudienceFormState(),
+  )
   const [error, setError] = useState<string | null>(null)
 
   const isCustomEventType = !COMMON_EVENT_TYPES.includes(eventType)
 
   useEffect(() => {
     if (initial) {
+      setAudience(audienceFormStateFromApi(initial))
       setName(initial.name)
       setDescription(initial.description ?? '')
       const knownType = COMMON_EVENT_TYPES.includes(initial.event_type)
@@ -81,6 +93,13 @@ export function PanelAlertRuleForm({ initial, onSubmit, onCancel, loading }: Pro
     if (!name.trim()) { setError(t('panelAlerts.validation.nameRequired')); return }
     if (!resolvedEventType) { setError(t('panelAlerts.validation.eventTypeRequired')); return }
     if (!alertText.trim()) { setError(t('panelAlerts.validation.alertTextRequired')); return }
+    const audienceError = validateAudienceForm(audience, {
+      teamRequired: t('panelAlerts.validation.teamRequired'),
+      studyTypeRequired: t('panelAlerts.validation.studyTypeRequired'),
+      studyRequired: t('panelAlerts.validation.studyRequired'),
+      moduleRequired: t('panelAlerts.validation.moduleRequired'),
+    })
+    if (audienceError) { setError(audienceError); return }
     try {
       await onSubmit({
         name: name.trim(),
@@ -94,6 +113,7 @@ export function PanelAlertRuleForm({ initial, onSubmit, onCancel, loading }: Pro
         visible_duration_hours: visibleDurationHours ? parseInt(visibleDurationHours, 10) : null,
         max_frequency_minutes: maxFrequencyMinutes ? parseInt(maxFrequencyMinutes, 10) : null,
         is_active: isActive,
+        ...buildAudiencePayload(audience),
       })
     } catch (err) {
       setError(err instanceof Error ? err.message : t('panelAlerts.errorSave'))
@@ -270,6 +290,8 @@ export function PanelAlertRuleForm({ initial, onSubmit, onCancel, loading }: Pro
           {t('panelAlerts.fields.isActive')}
         </span>
       </label>
+
+      <AlertAudienceFields value={audience} onChange={setAudience} disabled={loading} />
 
       {error && (
         <p role="alert" className="text-sm text-danger">{error}</p>

--- a/frontend/src/features/panel-alerts/types/alertAudience.ts
+++ b/frontend/src/features/panel-alerts/types/alertAudience.ts
@@ -1,0 +1,133 @@
+export type AudienceKind = 'academic' | 'team'
+export type AcademicLevel = 'study_type' | 'study' | 'module'
+
+/** Campos de audiencia tal como los devuelve la API. */
+export interface AlertAudienceFields {
+  notify_all: boolean
+  audience_kind: AudienceKind | null
+  academic_level: AcademicLevel | null
+  audience_study_type_id: string | null
+  audience_study_id: string | null
+  audience_module_id: string | null
+  audience_team_id: string | null
+}
+
+/** Estado del formulario de audiencia. */
+export interface AlertAudienceFormState {
+  notify_all: boolean
+  audience_kind: AudienceKind
+  academic_level: AcademicLevel
+  audience_study_type_id: string
+  audience_study_id: string
+  audience_module_id: string
+  audience_team_id: string
+}
+
+export type AlertAudiencePayload = {
+  notify_all: boolean
+  audience_kind?: AudienceKind
+  academic_level?: AcademicLevel
+  audience_study_type_id?: string
+  audience_study_id?: string
+  audience_module_id?: string
+  audience_team_id?: string
+}
+
+export function defaultAudienceFormState(): AlertAudienceFormState {
+  return {
+    notify_all: true,
+    audience_kind: 'academic',
+    academic_level: 'study_type',
+    audience_study_type_id: '',
+    audience_study_id: '',
+    audience_module_id: '',
+    audience_team_id: '',
+  }
+}
+
+export function audienceFormStateFromApi(
+  source?: Partial<AlertAudienceFields> | null,
+): AlertAudienceFormState {
+  if (!source || source.notify_all !== false) {
+    return defaultAudienceFormState()
+  }
+
+  return {
+    notify_all: false,
+    audience_kind: source.audience_kind === 'team' ? 'team' : 'academic',
+    academic_level:
+      source.academic_level === 'study' || source.academic_level === 'module'
+        ? source.academic_level
+        : 'study_type',
+    audience_study_type_id: source.audience_study_type_id ?? '',
+    audience_study_id: source.audience_study_id ?? '',
+    audience_module_id: source.audience_module_id ?? '',
+    audience_team_id: source.audience_team_id ?? '',
+  }
+}
+
+export function buildAudiencePayload(state: AlertAudienceFormState): AlertAudiencePayload {
+  if (state.notify_all) {
+    return { notify_all: true }
+  }
+
+  if (state.audience_kind === 'team') {
+    return {
+      notify_all: false,
+      audience_kind: 'team',
+      audience_team_id: state.audience_team_id,
+    }
+  }
+
+  const payload: AlertAudiencePayload = {
+    notify_all: false,
+    audience_kind: 'academic',
+    academic_level: state.academic_level,
+    audience_study_type_id: state.audience_study_type_id,
+  }
+
+  if (state.academic_level === 'study' || state.academic_level === 'module') {
+    payload.audience_study_id = state.audience_study_id
+  }
+
+  if (state.academic_level === 'module') {
+    payload.audience_module_id = state.audience_module_id
+  }
+
+  return payload
+}
+
+export function validateAudienceForm(
+  state: AlertAudienceFormState,
+  messages: {
+    teamRequired: string
+    studyTypeRequired: string
+    studyRequired: string
+    moduleRequired: string
+  },
+): string | null {
+  if (state.notify_all) {
+    return null
+  }
+
+  if (state.audience_kind === 'team') {
+    return state.audience_team_id ? null : messages.teamRequired
+  }
+
+  if (!state.audience_study_type_id) {
+    return messages.studyTypeRequired
+  }
+
+  if (
+    (state.academic_level === 'study' || state.academic_level === 'module') &&
+    !state.audience_study_id
+  ) {
+    return messages.studyRequired
+  }
+
+  if (state.academic_level === 'module' && !state.audience_module_id) {
+    return messages.moduleRequired
+  }
+
+  return null
+}

--- a/frontend/src/features/panel-alerts/types/panelAlert.ts
+++ b/frontend/src/features/panel-alerts/types/panelAlert.ts
@@ -1,7 +1,9 @@
+import type { AlertAudienceFields } from './alertAudience'
+
 export type Severity = 'critical' | 'high' | 'medium' | 'low'
 export type AlertSource = 'manual' | 'rule'
 
-export interface PanelAlert {
+export interface PanelAlert extends AlertAudienceFields {
   id: number
   text: string
   severity: Severity
@@ -33,6 +35,13 @@ export interface CreatePanelAlertInput {
   action_url?: string | null
   visible_from: string
   visible_until?: string | null
+  notify_all?: boolean
+  audience_kind?: 'academic' | 'team'
+  academic_level?: 'study_type' | 'study' | 'module'
+  audience_study_type_id?: string
+  audience_study_id?: string
+  audience_module_id?: string
+  audience_team_id?: string
 }
 
 export type UpdatePanelAlertInput = Partial<CreatePanelAlertInput>
@@ -55,7 +64,7 @@ export interface AlertCondition {
   value: string
 }
 
-export interface PanelAlertRule {
+export interface PanelAlertRule extends AlertAudienceFields {
   id: number
   name: string
   description: string | null
@@ -86,6 +95,13 @@ export interface CreatePanelAlertRuleInput {
   visible_duration_hours?: number | null
   max_frequency_minutes?: number | null
   is_active?: boolean
+  notify_all?: boolean
+  audience_kind?: 'academic' | 'team'
+  academic_level?: 'study_type' | 'study' | 'module'
+  audience_study_type_id?: string
+  audience_study_id?: string
+  audience_module_id?: string
+  audience_team_id?: string
 }
 
 export type UpdatePanelAlertRuleInput = Partial<CreatePanelAlertRuleInput>

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -348,12 +348,40 @@
       "isActive": "Rule active",
       "lastTriggeredAt": "Last triggered"
     },
+    "audience": {
+      "sectionTitle": "Recipients",
+      "notifyAll": "Send to all active users",
+      "kindAcademic": "Academic context",
+      "kindTeam": "Team or department",
+      "academicLevel": "Scope level",
+      "level": {
+        "study_type": "Study type",
+        "study": "Study",
+        "module": "Module"
+      },
+      "studyType": "Study type",
+      "study": "Study",
+      "module": "Module",
+      "team": "Team",
+      "department": "Department",
+      "selectPlaceholder": "Select…",
+      "selectStudyTypeFirst": "Select a study type first.",
+      "selectStudyFirst": "Select a study first.",
+      "contextError": "Could not load your academic context.",
+      "emptyContext": "You have no academic contexts or teams assigned to narrow the audience.",
+      "noTeamsAssigned": "You have no teams or departments assigned on your profile. Check Departments and Work teams in your profile, or ask to be added in Odoo.",
+      "teamsUnavailable": "Team data is temporarily unavailable. Please try again later."
+    },
     "validation": {
       "nameRequired": "Name is required.",
       "eventTypeRequired": "Event type is required.",
       "alertTextRequired": "Alert text is required.",
       "textRequired": "Alert text is required.",
-      "visibleFromRequired": "Start date is required."
+      "visibleFromRequired": "Start date is required.",
+      "teamRequired": "Select a team or department.",
+      "studyTypeRequired": "Select a study type.",
+      "studyRequired": "Select a study.",
+      "moduleRequired": "Select a module."
     }
   },
   "notifications": {

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -348,12 +348,40 @@
       "isActive": "Regla activa",
       "lastTriggeredAt": "Última activación"
     },
+    "audience": {
+      "sectionTitle": "Destinatarios",
+      "notifyAll": "Enviar a todos los usuarios activos",
+      "kindAcademic": "Contexto académico",
+      "kindTeam": "Equipo o departamento",
+      "academicLevel": "Nivel de alcance",
+      "level": {
+        "study_type": "Tipo de estudio",
+        "study": "Estudio",
+        "module": "Módulo"
+      },
+      "studyType": "Tipo de estudio",
+      "study": "Estudio",
+      "module": "Módulo",
+      "team": "Equipo",
+      "department": "Departamento",
+      "selectPlaceholder": "Seleccionar…",
+      "selectStudyTypeFirst": "Selecciona primero un tipo de estudio.",
+      "selectStudyFirst": "Selecciona primero un estudio.",
+      "contextError": "No se pudo cargar tu contexto académico.",
+      "emptyContext": "No tienes contextos académicos ni equipos asignados para acotar la audiencia.",
+      "noTeamsAssigned": "No tienes equipos ni departamentos asignados en tu perfil. Revisa la sección Departamentos y Equipos en tu perfil, o pide que te asignen membresía en Odoo.",
+      "teamsUnavailable": "Los datos de equipos no están disponibles ahora mismo. Inténtalo más tarde."
+    },
     "validation": {
       "nameRequired": "El nombre es obligatorio.",
       "eventTypeRequired": "El tipo de evento es obligatorio.",
       "alertTextRequired": "El texto de la alerta es obligatorio.",
       "textRequired": "El texto de la alerta es obligatorio.",
-      "visibleFromRequired": "La fecha de inicio es obligatoria."
+      "visibleFromRequired": "La fecha de inicio es obligatoria.",
+      "teamRequired": "Selecciona un equipo o departamento.",
+      "studyTypeRequired": "Selecciona un tipo de estudio.",
+      "studyRequired": "Selecciona un estudio.",
+      "moduleRequired": "Selecciona un módulo."
     }
   },
   "notifications": {

--- a/frontend/src/i18n/locales/va/common.json
+++ b/frontend/src/i18n/locales/va/common.json
@@ -348,12 +348,40 @@
       "isActive": "Regla activa",
       "lastTriggeredAt": "Última activació"
     },
+    "audience": {
+      "sectionTitle": "Destinataris",
+      "notifyAll": "Enviar a tots els usuaris actius",
+      "kindAcademic": "Context acadèmic",
+      "kindTeam": "Equip o departament",
+      "academicLevel": "Nivell d'abast",
+      "level": {
+        "study_type": "Tipus d'estudi",
+        "study": "Estudi",
+        "module": "Mòdul"
+      },
+      "studyType": "Tipus d'estudi",
+      "study": "Estudi",
+      "module": "Mòdul",
+      "team": "Equip",
+      "department": "Departament",
+      "selectPlaceholder": "Seleccionar…",
+      "selectStudyTypeFirst": "Selecciona primer un tipus d'estudi.",
+      "selectStudyFirst": "Selecciona primer un estudi.",
+      "contextError": "No s'ha pogut carregar el teu context acadèmic.",
+      "emptyContext": "No tens contextos acadèmics ni equips assignats per acotar l'audiència.",
+      "noTeamsAssigned": "No tens equips ni departaments assignats al teu perfil. Revisa Departaments i Equips al perfil, o demana que t'assignin membresia a Odoo.",
+      "teamsUnavailable": "Les dades d'equips no estan disponibles ara. Torna-ho a provar més tard."
+    },
     "validation": {
       "nameRequired": "El nom és obligatori.",
       "eventTypeRequired": "El tipus d'esdeveniment és obligatori.",
       "alertTextRequired": "El text de l'alerta és obligatori.",
       "textRequired": "El text de l'alerta és obligatori.",
-      "visibleFromRequired": "La data d'inici és obligatòria."
+      "visibleFromRequired": "La data d'inici és obligatòria.",
+      "teamRequired": "Selecciona un equip o departament.",
+      "studyTypeRequired": "Selecciona un tipus d'estudi.",
+      "studyRequired": "Selecciona un estudi.",
+      "moduleRequired": "Selecciona un mòdul."
     }
   },
   "notifications": {


### PR DESCRIPTION
Añade audiencia configurable al crear alertas de panel, reglas de panel y reglas de sistema: envío a todos los usuarios activos o acotado por contexto académico (tipo de estudio / estudio / módulo en cascada) o por equipo o departamento, usando el contexto del usuario creador