### PR TITLE
Fix/renderizar html alertas panel

### DIFF
--- a/frontend/src/features/dashboard/widgets/UserAlertsWidget.test.tsx
+++ b/frontend/src/features/dashboard/widgets/UserAlertsWidget.test.tsx
@@ -99,6 +99,15 @@ describe('UserAlertsWidget', () => {
       expect(screen.getByText('Segunda alerta')).toBeTruthy()
     })
 
+    it('renderiza el HTML del editor en lugar de mostrar etiquetas literales', () => {
+      setupMocks({
+        alerts: [{ id: '1', text: '<p><strong>Prueba</strong></p>', color: 'amber' }],
+      })
+      render(<UserAlertsWidget />)
+      expect(screen.getByText('Prueba')).toBeTruthy()
+      expect(screen.queryByText('<p><strong>Prueba</strong></p>')).toBeNull()
+    })
+
     it('muestra el botón de acción cuando actionLabel está presente', () => {
       setupMocks({
         alerts: [{ id: '1', text: 'Alerta', color: 'blue', actionLabel: 'Ver detalle' }],

--- a/frontend/src/features/dashboard/widgets/UserAlertsWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/UserAlertsWidget.tsx
@@ -1,3 +1,4 @@
+import { EditorContentHtml } from '@ceedcv-maya/shared-editor-react'
 import { Button } from '@ceedcv-maya/shared-ui-react'
 import { useTranslation } from 'react-i18next'
 import { useUserAlerts } from '../../alerts/hooks/useUserAlerts'
@@ -181,7 +182,10 @@ function UserAlertsWidget() {
                   key={alert.id}
                   className={`flex items-center gap-2 px-3 py-2 rounded-lg border text-sm ${colorCls}`}
                 >
-                  <span className="flex-1">{alert.text}</span>
+                  <EditorContentHtml
+                    html={alert.text}
+                    className="flex-1 min-w-0 text-sm [&_p]:m-0"
+                  />
                   {alert.actionLabel && (
                     <Button
                       variant="unstyled"

--- a/frontend/src/features/notifications/pages/NotificationDetailPage.tsx
+++ b/frontend/src/features/notifications/pages/NotificationDetailPage.tsx
@@ -1,5 +1,7 @@
+import { type ReactNode, useMemo } from 'react'
+import { EditorContentHtml, sanitizeEditorHtml } from '@ceedcv-maya/shared-editor-react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { Badge, Button, Card, PageTitle, Spinner, useToast } from '@ceedcv-maya/shared-ui-react'
+import { Badge, Button, PageTitle, Spinner, useToast } from '@ceedcv-maya/shared-ui-react'
 import { useLocale } from '@ceedcv-maya/shared-i18n-react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useUserProfile } from '../../user-profile'
@@ -7,13 +9,39 @@ import { DASHBOARD_PERMISSIONS } from '../../../permissions'
 import { useNotification } from '../hooks/useNotification'
 import { markNotificationRead } from '../api/notificationsApi'
 
-function DetailRow({ label, value }: { label: string; value: React.ReactNode }) {
+function editorHtmlToPlainText(html: string): string {
+  const safe = sanitizeEditorHtml(html)
+  if (!safe) return ''
+  if (typeof document !== 'undefined') {
+    const el = document.createElement('div')
+    el.innerHTML = safe
+    return (el.textContent ?? '').replace(/\s+/g, ' ').trim()
+  }
+  return safe.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
+function DetailSection({ title, children }: { title: string; children: ReactNode }) {
   return (
-    <div className="grid grid-cols-[160px_1fr] gap-2 py-2 border-b border-ui-border-l dark:border-ui-dark-border-l last:border-0">
-      <dt className="text-xs font-semibold uppercase tracking-wide text-text-secondary dark:text-text-dark-secondary">
+    <div className="p-4 sm:p-5 rounded-lg border border-ui-border dark:border-ui-dark-border bg-ui-body dark:bg-ui-dark-card">
+      <h2 className="m-0 mb-4 text-base font-semibold text-text-primary dark:text-text-dark-secondary">
+        {title}
+      </h2>
+      {children}
+    </div>
+  )
+}
+
+function DetailDl({ children }: { children: ReactNode }) {
+  return <dl className="m-0 flex flex-col gap-3">{children}</dl>
+}
+
+function DetailRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-[160px_1fr] gap-1 sm:gap-3 items-baseline">
+      <dt className="m-0 text-sm font-medium text-text-secondary dark:text-text-dark-secondary">
         {label}
       </dt>
-      <dd className="text-sm text-text-primary dark:text-text-dark-primary">{value}</dd>
+      <dd className="m-0 text-base text-text-primary dark:text-text-dark-primary">{value}</dd>
     </div>
   )
 }
@@ -42,125 +70,149 @@ export default function NotificationDetailPage() {
     onError: () => toast({ tone: 'danger', title: t('notifications.markReadError') }),
   })
 
+  const pageTitle = useMemo(() => {
+    if (!notification) return t('notifications.pageTitle')
+    const plain =
+      editorHtmlToPlainText(notification.title) ||
+      editorHtmlToPlainText(notification.body ?? '')
+    return plain || `#${notification.id}`
+  }, [notification, t])
+
+  const messageHtml = notification?.body ?? notification?.title ?? ''
+
   if (!canShow) {
     return (
-      <div className="max-w-[800px] mx-auto p-4">
-        <PageTitle title={t('notifications.pageTitle')} />
+      <>
+        <PageTitle title={t('notifications.pageTitle')} onBack={() => navigate('/notifications')} />
         <p className="text-text-primary dark:text-text-dark-primary" role="status">
           {t('notifications.noPermission')}
         </p>
-      </div>
+      </>
     )
   }
 
   if (isLoading) {
     return (
-      <div className="flex justify-center py-16">
-        <Spinner size="lg" />
-      </div>
+      <>
+        <PageTitle title={t('notifications.pageTitle')} onBack={() => navigate('/notifications')} />
+        <div className="flex justify-center py-16">
+          <Spinner size="lg" />
+        </div>
+      </>
     )
   }
 
   if (error || !notification) {
     return (
-      <div className="max-w-[800px] mx-auto p-4">
+      <>
+        <PageTitle title={t('notifications.pageTitle')} onBack={() => navigate('/notifications')} />
         <p role="alert" className="text-danger text-sm">
           {t('notifications.loadError')}
         </p>
-        <Button variant="outline" size="sm" onClick={() => navigate('/notifications')} className="mt-4">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => navigate('/notifications')}
+          className="mt-4"
+        >
           {t('notifications.backToList')}
         </Button>
-      </div>
+      </>
     )
   }
 
   return (
-    <div className="max-w-[800px] mx-auto p-4 space-y-4">
-      <div className="flex items-center gap-2">
-        <Button variant="ghost" size="sm" onClick={() => navigate('/notifications')}>
-          ← {t('notifications.backToList')}
-        </Button>
-      </div>
+    <>
+      <PageTitle
+        title={pageTitle}
+        subtitle={`#${notification.id} · ${notification.app} · ${notification.type}`}
+        onBack={() => navigate('/notifications')}
+        actions={
+          !notification.read_at && canUpdate ? (
+            <Button
+              variant="primary"
+              size="sm"
+              disabled={markReadMutation.isPending}
+              onClick={() => markReadMutation.mutate()}
+              className="w-full sm:w-auto"
+            >
+              {markReadMutation.isPending ? t('notifications.markingRead') : t('notifications.markRead')}
+            </Button>
+          ) : null
+        }
+      />
 
-      <div className="flex items-start justify-between gap-4">
-        <PageTitle
-          title={notification.title}
-          subtitle={`#${notification.id} · ${notification.app} · ${notification.type}`}
-        />
-        {!notification.read_at && canUpdate && (
-          <Button
-            variant="outlineTeal"
-            size="sm"
-            disabled={markReadMutation.isPending}
-            onClick={() => markReadMutation.mutate()}
-          >
-            {markReadMutation.isPending ? t('notifications.markingRead') : t('notifications.markRead')}
-          </Button>
-        )}
-      </div>
-
-      <Card>
-        <dl>
-          <DetailRow
-            label={t('notifications.fields.status')}
-            value={
-              notification.read_at ? (
-                <Badge variant="neutral" size="sm">{t('notifications.status.read')}</Badge>
-              ) : (
-                <Badge variant="info" size="sm">{t('notifications.status.unread')}</Badge>
-              )
-            }
-          />
-          <DetailRow
-            label={t('notifications.fields.app')}
-            value={<Badge variant="neutral" size="sm">{notification.app}</Badge>}
-          />
-          <DetailRow
-            label={t('notifications.fields.type')}
-            value={<code className="font-mono text-xs">{notification.type}</code>}
-          />
-          {notification.body && (
-            <DetailRow label={t('notifications.fields.body')} value={notification.body} />
-          )}
-          <DetailRow
-            label={t('notifications.fields.channels')}
-            value={
-              <div className="flex flex-wrap gap-1">
-                {notification.channels.map((ch) => (
-                  <Badge key={ch} variant="neutral" size="sm">{ch}</Badge>
-                ))}
-              </div>
-            }
-          />
-          <DetailRow
-            label={t('notifications.fields.createdAt')}
-            value={new Date(notification.created_at).toLocaleString()}
-          />
-          {notification.read_at && (
-            <DetailRow
-              label={t('notifications.fields.readAt')}
-              value={new Date(notification.read_at).toLocaleString()}
+      <section className="max-w-[600px] mx-auto flex flex-col gap-4 sm:gap-6">
+        {messageHtml ? (
+          <DetailSection title={t('notifications.detailMessage')}>
+            <EditorContentHtml
+              html={messageHtml}
+              className="maya-editor-content text-base text-text-primary dark:text-text-dark-primary [&_p]:m-0 [&_p+p]:mt-2"
             />
-          )}
-          {notification.message_id && (
-            <DetailRow
-              label={t('notifications.fields.messageId')}
-              value={<code className="font-mono text-xs break-all">{notification.message_id}</code>}
-            />
-          )}
-        </dl>
-      </Card>
+          </DetailSection>
+        ) : null}
 
-      {notification.metadata && Object.keys(notification.metadata).length > 0 && (
-        <Card>
-          <h3 className="text-sm font-semibold text-text-primary dark:text-text-dark-primary mb-3">
-            {t('notifications.fields.metadata')}
-          </h3>
-          <pre className="p-3 bg-ui-body dark:bg-ui-dark-bg rounded-md text-xs font-mono overflow-auto max-h-[400px] text-text-primary dark:text-text-dark-primary">
-            {JSON.stringify(notification.metadata, null, 2)}
-          </pre>
-        </Card>
-      )}
-    </div>
+        <DetailSection title={t('notifications.detailInfo')}>
+          <DetailDl>
+            <DetailRow
+              label={t('notifications.fields.status')}
+              value={
+                notification.read_at ? (
+                  <Badge variant="neutral" size="sm">{t('notifications.status.read')}</Badge>
+                ) : (
+                  <Badge variant="info" size="sm">{t('notifications.status.unread')}</Badge>
+                )
+              }
+            />
+            <DetailRow
+              label={t('notifications.fields.app')}
+              value={<Badge variant="neutral" size="sm">{notification.app}</Badge>}
+            />
+            <DetailRow
+              label={t('notifications.fields.type')}
+              value={<code className="font-mono text-sm">{notification.type}</code>}
+            />
+            <DetailRow
+              label={t('notifications.fields.channels')}
+              value={
+                notification.channels.length > 0 ? (
+                  <div className="flex flex-wrap gap-2">
+                    {notification.channels.map((ch) => (
+                      <Badge key={ch} variant="neutral" size="sm">{ch}</Badge>
+                    ))}
+                  </div>
+                ) : (
+                  '—'
+                )
+              }
+            />
+            <DetailRow
+              label={t('notifications.fields.createdAt')}
+              value={new Date(notification.created_at).toLocaleString()}
+            />
+            {notification.read_at ? (
+              <DetailRow
+                label={t('notifications.fields.readAt')}
+                value={new Date(notification.read_at).toLocaleString()}
+              />
+            ) : null}
+            {notification.message_id ? (
+              <DetailRow
+                label={t('notifications.fields.messageId')}
+                value={<code className="font-mono text-sm break-all">{notification.message_id}</code>}
+              />
+            ) : null}
+          </DetailDl>
+        </DetailSection>
+
+        {notification.metadata && Object.keys(notification.metadata).length > 0 ? (
+          <DetailSection title={t('notifications.fields.metadata')}>
+            <pre className="m-0 p-3 rounded-md bg-ui-card dark:bg-ui-dark-bg border border-ui-border-l dark:border-ui-dark-border-l text-xs font-mono overflow-auto max-h-[400px] text-text-primary dark:text-text-dark-primary">
+              {JSON.stringify(notification.metadata, null, 2)}
+            </pre>
+          </DetailSection>
+        ) : null}
+      </section>
+    </>
   )
 }

--- a/frontend/src/features/notifications/pages/NotificationsPage.tsx
+++ b/frontend/src/features/notifications/pages/NotificationsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
+import { EditorContentHtml } from '@ceedcv-maya/shared-editor-react'
 import {
   Badge,
   Button,
@@ -114,9 +115,14 @@ export default function NotificationsPage() {
         id: 'title',
         header: t('notifications.fields.title'),
         cell: (n) => (
-          <span className={n.read_at ? 'text-text-secondary dark:text-text-dark-secondary' : 'font-semibold'}>
-            {n.title}
-          </span>
+          <EditorContentHtml
+            html={n.title}
+            className={`line-clamp-2 text-sm [&_p]:m-0 ${
+              n.read_at
+                ? 'text-text-secondary dark:text-text-dark-secondary'
+                : 'font-semibold text-text-primary dark:text-text-dark-primary'
+            }`}
+          />
         ),
         alwaysVisible: true,
       },
@@ -217,15 +223,14 @@ export default function NotificationsPage() {
                 aria-hidden
               />
               <div className="flex-1 min-w-0">
-                <p
-                  className={`text-sm truncate ${
+                <EditorContentHtml
+                  html={n.title}
+                  className={`text-sm truncate line-clamp-1 [&_p]:inline [&_p]:m-0 ${
                     n.read_at
                       ? 'text-text-secondary dark:text-text-dark-secondary'
                       : 'font-semibold text-text-primary dark:text-text-dark-primary'
                   }`}
-                >
-                  {n.title}
-                </p>
+                />
                 <div className="flex items-center gap-2 mt-1">
                   <Badge variant="neutral" size="sm">{n.app}</Badge>
                   <span className="text-xs text-text-muted dark:text-text-dark-muted truncate">{n.type}</span>
@@ -237,10 +242,13 @@ export default function NotificationsPage() {
             </div>
           )}
           flipCardRender={(n) => ({
-            back: (
-              <p className="text-sm text-text-secondary dark:text-text-dark-secondary leading-relaxed line-clamp-4">
-                {n.body || '—'}
-              </p>
+            back: n.body ? (
+              <EditorContentHtml
+                html={n.body}
+                className="text-sm text-text-secondary dark:text-text-dark-secondary leading-relaxed line-clamp-4 [&_p]:m-0"
+              />
+            ) : (
+              <p className="text-sm text-text-secondary dark:text-text-dark-secondary">—</p>
             ),
             backAction: canUpdate && !n.read_at ? (
               <button

--- a/frontend/src/features/panel-alerts/pages/PanelAlertsPage.tsx
+++ b/frontend/src/features/panel-alerts/pages/PanelAlertsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
+import { EditorContentHtml } from '@ceedcv-maya/shared-editor-react'
 import {
   Badge,
   Button,
@@ -166,7 +167,12 @@ export default function PanelAlertsPage() {
       {
         id: 'text',
         header: t('panelAlerts.fields.text'),
-        cell: (a) => <span className="line-clamp-2 text-sm">{a.text}</span>,
+        cell: (a) => (
+          <EditorContentHtml
+            html={a.text}
+            className="line-clamp-2 text-sm [&_p]:m-0"
+          />
+        ),
         alwaysVisible: true,
       },
       {

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -371,6 +371,8 @@
     "markReadSuccess": "Notification marked as read.",
     "markReadError": "Could not mark as read.",
     "backToList": "Back to list",
+    "detailMessage": "Message",
+    "detailInfo": "Information",
     "loadError": "Could not load the notification.",
     "empty": "No notifications for the selected filters.",
     "noPermission": "You do not have permission to view notifications.",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -371,6 +371,8 @@
     "markReadSuccess": "Notificación marcada como leída.",
     "markReadError": "No se pudo marcar como leída.",
     "backToList": "Volver a la lista",
+    "detailMessage": "Mensaje",
+    "detailInfo": "Información",
     "loadError": "No se pudo cargar la notificación.",
     "empty": "No hay notificaciones para los filtros seleccionados.",
     "noPermission": "No tienes permiso para ver las notificaciones.",

--- a/frontend/src/i18n/locales/va/common.json
+++ b/frontend/src/i18n/locales/va/common.json
@@ -371,6 +371,8 @@
     "markReadSuccess": "Notificació marcada com llegida.",
     "markReadError": "No s'ha pogut marcar com llegida.",
     "backToList": "Tornar a la llista",
+    "detailMessage": "Missatge",
+    "detailInfo": "Informació",
     "loadError": "No s'ha pogut carregar la notificació.",
     "empty": "No hi ha notificacions per als filtres seleccionats.",
     "noPermission": "No tens permís per veure les notificacions.",


### PR DESCRIPTION
- Renderiza el HTML del editor (MayaEditor) en alertas del panel, listado de notificaciones y vista de detalle, usando `EditorContentHtml` con sanitización DOMPurify.
- Alinea la pantalla de detalle de notificaciones con el layout de Perfil (`PageTitle` con volver, secciones Mensaje / Información, ancho `max-w-[600px]`).
- El título del detalle se muestra en texto plano; el cuerpo conserva el formato (negrita, párrafos, etc.).
