### PR TITLE
fix: local timezone for alerts and notifications dates

### DIFF
--- a/frontend/src/features/notifications/pages/NotificationDetailPage.tsx
+++ b/frontend/src/features/notifications/pages/NotificationDetailPage.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, useMemo } from 'react'
 import { EditorContentHtml, sanitizeEditorHtml } from '@ceedcv-maya/shared-editor-react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { Badge, Button, PageTitle, Spinner, useToast } from '@ceedcv-maya/shared-ui-react'
+import { Badge, Button, PageTitle, Spinner, formatDateTime, useToast } from '@ceedcv-maya/shared-ui-react'
 import { useLocale } from '@ceedcv-maya/shared-i18n-react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useUserProfile } from '../../user-profile'
@@ -50,7 +50,7 @@ export default function NotificationDetailPage() {
   const { id } = useParams<{ id: string }>()
   const notifId = id != null && /^\d+$/.test(id) ? Number(id) : undefined
   const navigate = useNavigate()
-  const { t } = useLocale()
+  const { t, dateLocale } = useLocale()
   const { toast } = useToast()
   const queryClient = useQueryClient()
   const { hasPermission } = useUserProfile()
@@ -188,12 +188,12 @@ export default function NotificationDetailPage() {
             />
             <DetailRow
               label={t('notifications.fields.createdAt')}
-              value={new Date(notification.created_at).toLocaleString()}
+              value={formatDateTime(notification.created_at, dateLocale)}
             />
             {notification.read_at ? (
               <DetailRow
                 label={t('notifications.fields.readAt')}
-                value={new Date(notification.read_at).toLocaleString()}
+                value={formatDateTime(notification.read_at, dateLocale)}
               />
             ) : null}
             {notification.message_id ? (

--- a/frontend/src/features/notifications/pages/NotificationsPage.tsx
+++ b/frontend/src/features/notifications/pages/NotificationsPage.tsx
@@ -6,6 +6,7 @@ import {
   Badge,
   Button,
   DataTable,
+  formatDateTime,
   FilterField,
   PageTitle,
   Pagination,
@@ -25,7 +26,7 @@ import type { Notification, NotificationListFilters } from '../types/notificatio
 const POLL_MS = 60_000
 
 export default function NotificationsPage() {
-  const { t } = useLocale()
+  const { t, dateLocale } = useLocale()
   const navigate = useNavigate()
   const { toast } = useToast()
   const { hasPermission } = useUserProfile()
@@ -149,12 +150,12 @@ export default function NotificationsPage() {
       {
         id: 'created_at',
         header: t('notifications.fields.createdAt'),
-        cell: (n) => new Date(n.created_at).toLocaleString(),
+        cell: (n) => formatDateTime(n.created_at, dateLocale),
         sortable: true,
         width: '180px',
       },
     ],
-    [t],
+    [dateLocale, t],
   )
 
   const totalPages = meta?.last_page ?? 1
@@ -236,7 +237,7 @@ export default function NotificationsPage() {
                   <span className="text-xs text-text-muted dark:text-text-dark-muted truncate">{n.type}</span>
                 </div>
                 <p className="text-xs text-text-muted dark:text-text-dark-muted mt-1">
-                  {new Date(n.created_at).toLocaleString()}
+                  {formatDateTime(n.created_at, dateLocale)}
                 </p>
               </div>
             </div>

--- a/frontend/src/features/panel-alerts/components/PanelAlertForm.tsx
+++ b/frontend/src/features/panel-alerts/components/PanelAlertForm.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from 'react'
-import { Button, Select, TextInput } from '@ceedcv-maya/shared-ui-react'
+import {
+  Button,
+  Select,
+  TextInput,
+  datetimeLocalToIso,
+  toDatetimeLocalValue,
+} from '@ceedcv-maya/shared-ui-react'
 import { MayaEditor } from '@ceedcv-maya/shared-editor-react'
 import { useLocale } from '@ceedcv-maya/shared-i18n-react'
 import type { CreatePanelAlertInput, PanelAlert, Severity } from '../types/panelAlert'
@@ -13,11 +19,6 @@ interface Props {
 
 const SEVERITIES: Severity[] = ['critical', 'high', 'medium', 'low']
 
-function toDatetimeLocal(iso: string | null | undefined): string {
-  if (!iso) return ''
-  return iso.slice(0, 16)
-}
-
 export function PanelAlertForm({ initial, onSubmit, onCancel, loading }: Props) {
   const { t } = useLocale()
 
@@ -25,8 +26,8 @@ export function PanelAlertForm({ initial, onSubmit, onCancel, loading }: Props) 
   const [severity, setSeverity] = useState<Severity>(initial?.severity ?? 'medium')
   const [actionLabel, setActionLabel] = useState(initial?.action_label ?? '')
   const [actionUrl, setActionUrl] = useState(initial?.action_url ?? '')
-  const [visibleFrom, setVisibleFrom] = useState(toDatetimeLocal(initial?.visible_from))
-  const [visibleUntil, setVisibleUntil] = useState(toDatetimeLocal(initial?.visible_until))
+  const [visibleFrom, setVisibleFrom] = useState(toDatetimeLocalValue(initial?.visible_from))
+  const [visibleUntil, setVisibleUntil] = useState(toDatetimeLocalValue(initial?.visible_until))
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -35,8 +36,8 @@ export function PanelAlertForm({ initial, onSubmit, onCancel, loading }: Props) 
       setSeverity(initial.severity)
       setActionLabel(initial.action_label ?? '')
       setActionUrl(initial.action_url ?? '')
-      setVisibleFrom(toDatetimeLocal(initial.visible_from))
-      setVisibleUntil(toDatetimeLocal(initial.visible_until))
+      setVisibleFrom(toDatetimeLocalValue(initial.visible_from))
+      setVisibleUntil(toDatetimeLocalValue(initial.visible_until))
     }
   }, [initial])
 
@@ -51,8 +52,8 @@ export function PanelAlertForm({ initial, onSubmit, onCancel, loading }: Props) 
         severity,
         action_label: actionLabel.trim() || null,
         action_url: actionUrl.trim() || null,
-        visible_from: new Date(visibleFrom).toISOString(),
-        visible_until: visibleUntil ? new Date(visibleUntil).toISOString() : null,
+        visible_from: datetimeLocalToIso(visibleFrom)!,
+        visible_until: visibleUntil ? datetimeLocalToIso(visibleUntil) : null,
       })
     } catch (err) {
       setError(err instanceof Error ? err.message : t('panelAlerts.errorSave'))

--- a/frontend/src/features/panel-alerts/pages/PanelAlertsPage.tsx
+++ b/frontend/src/features/panel-alerts/pages/PanelAlertsPage.tsx
@@ -5,6 +5,7 @@ import {
   Badge,
   Button,
   DataTable,
+  formatDateTime,
   FilterField,
   PageTitle,
   Pagination,
@@ -72,7 +73,7 @@ function Modal({ title, onClose, children }: { title: string; onClose: () => voi
 }
 
 export default function PanelAlertsPage() {
-  const { t } = useLocale()
+  const { t, dateLocale } = useLocale()
   const { show: toast } = useToast()
   const navigate = useNavigate()
   const { hasPermission } = useUserProfile()
@@ -178,14 +179,14 @@ export default function PanelAlertsPage() {
       {
         id: 'visible_from',
         header: t('panelAlerts.fields.visibleFrom'),
-        cell: (a) => new Date(a.visible_from).toLocaleString(),
+        cell: (a) => formatDateTime(a.visible_from, dateLocale),
         sortable: true,
         width: '160px',
       },
       {
         id: 'visible_until',
         header: t('panelAlerts.fields.visibleUntil'),
-        cell: (a) => a.visible_until ? new Date(a.visible_until).toLocaleString() : '—',
+        cell: (a) => (a.visible_until ? formatDateTime(a.visible_until, dateLocale) : '—'),
         width: '160px',
       },
       {
@@ -240,7 +241,7 @@ export default function PanelAlertsPage() {
 
       return columns
     },
-    [canDeleteAlert, canUpdateAlert, onDelete, t, toast],
+    [canDeleteAlert, canUpdateAlert, dateLocale, onDelete, t, toast],
   )
 
   // ── Rule columns ──────────────────────────────────────────────
@@ -282,7 +283,7 @@ export default function PanelAlertsPage() {
       {
         id: 'last_triggered_at',
         header: t('panelAlerts.fields.lastTriggeredAt'),
-        cell: (r) => r.last_triggered_at ? new Date(r.last_triggered_at).toLocaleString() : '—',
+        cell: (r) => (r.last_triggered_at ? formatDateTime(r.last_triggered_at, dateLocale) : '—'),
         width: '160px',
       },
       ]
@@ -329,7 +330,7 @@ export default function PanelAlertsPage() {
 
       return columns
     },
-    [canDeleteRule, canUpdateRule, onDeleteRule, t, toast],
+    [canDeleteRule, canUpdateRule, dateLocale, onDeleteRule, t, toast],
   )
 
   // ── Handlers ──────────────────────────────────────────────────

--- a/frontend/src/features/system-alerts/components/AlertRow.tsx
+++ b/frontend/src/features/system-alerts/components/AlertRow.tsx
@@ -1,5 +1,5 @@
 import { useActionState } from 'react'
-import { Button } from '@ceedcv-maya/shared-ui-react'
+import { Button, formatDateTime } from '@ceedcv-maya/shared-ui-react'
 import { useLocale } from '@ceedcv-maya/shared-i18n-react'
 
 export interface SystemAlert {
@@ -39,7 +39,7 @@ interface AlertRowProps {
  * surfaced inline without a global loading flag.
  */
 export function AlertRow({ alert, onAcknowledge, onResolve }: AlertRowProps) {
-  const { t } = useLocale()
+  const { t, dateLocale } = useLocale()
 
   const [ackState, ackAction, ackPending] = useActionState<ActionState, void>(
     async (_prev) => {
@@ -77,7 +77,7 @@ export function AlertRow({ alert, onAcknowledge, onResolve }: AlertRowProps) {
           <strong>{alert.title}</strong>
           <div className="text-sm text-text-muted dark:text-text-dark-muted">
             {alert.rule_slug || t('dashboard.systemAlerts.adHoc')} · {alert.source} ·{' '}
-            {new Date(alert.created_at).toLocaleString()}
+            {formatDateTime(alert.created_at, dateLocale)}
           </div>
         </div>
         <div className="flex gap-1.5">


### PR DESCRIPTION
- Formulario de alertas del panel: `toDatetimeLocalValue` / `datetimeLocalToIso` al cargar y guardar `visible_from` / `visible_until`.
- Listados y detalle: `formatDateTime(..., dateLocale)` en alertas del panel, notificaciones y alertas de sistema.
